### PR TITLE
Change variable used to comply given example.

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l01c01_introduction_to_colab_and_python.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l01c01_introduction_to_colab_and_python.ipynb
@@ -135,7 +135,7 @@
         "for i in range(8, 25, 5):  # i=8, 13, 18, 23 (start, stop, step)\n",
         "  print(\"--- Now running with i: {}\".format(i))\n",
         "  r = HelloWorldXY(i,i)\n",
-        "  print(\"Result from HelloWorld: {}\".format(i, r))"
+        "  print(\"Result from HelloWorld: {}\".format(r))"
       ]
     },
     {
@@ -272,7 +272,7 @@
       "outputs": [],
       "source": [
         "print(\"\\nYou can print the type of anything\")\n",
-        "print(\"Type of b: {}, type of b[0]: {}\".format(type(a), type(a[0])))"
+        "print(\"Type of b: {}, type of b[0]: {}\".format(type(b), type(b[0])))"
       ]
     },
     {


### PR DESCRIPTION
Changes:
* `print("Result from HelloWorld: {}".format(i, r))` => to use `r` only.
* `print("Type of b: {}, type of b[0]: {}".format(type(a), type(a[0])))` => to use variable `b` instead of `a`