### PR TITLE
Typo: 126 neurons -> 128 neurons

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l03c01_classifying_images_of_clothing.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l03c01_classifying_images_of_clothing.ipynb
@@ -483,7 +483,7 @@
         "\n",
         "* **input** `tf.keras.layers.Flatten` — This layer transforms the images from a 2d-array of 28 $\\times$ 28 pixels), to a 1d-array of 784 pixels (28\\*28). Think of this layer as unstacking rows of pixels in the image and lining them up. This layer has no parameters to learn, as it only reformats the data.\n",
         "\n",
-        "* **\"hidden\"** `tf.keras.layers.Dense`— A densely connected layer of 126 neurons. Each neuron (or node) takes input from all 784 nodes in the previous layer, weighting that input according to hidden parameters which will be learned during training, and outputs a single value to the next layer.\n",
+        "* **\"hidden\"** `tf.keras.layers.Dense`— A densely connected layer of 128 neurons. Each neuron (or node) takes input from all 784 nodes in the previous layer, weighting that input according to hidden parameters which will be learned during training, and outputs a single value to the next layer.\n",
         "\n",
         "* **output** `tf.keras.layers.Dense` — A 10-node *softmax* layer. Each node represents a class of clothing. As in the previous layer, each node takes input from the 128 nodes in the layer before it, weights thats input according to learned parameters, and outputs a value in the range `[0, 1]`, representing the probability that the image belongs to that class. The sum of all 10 node values is 1.\n",
         "\n",


### PR DESCRIPTION
In the code 128 neurons are created but the description only mentions 126.