### PR TITLE
TFLite classification example fix permission crash

### DIFF
--- a/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/CameraActivity.java
+++ b/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/CameraActivity.java
@@ -369,8 +369,7 @@ public abstract class CameraActivity extends AppCompatActivity
       final int requestCode, final String[] permissions, final int[] grantResults) {
     if (requestCode == PERMISSIONS_REQUEST) {
       if (grantResults.length > 0
-          && grantResults[0] == PackageManager.PERMISSION_GRANTED
-          && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+          && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
         setFragment();
       } else {
         requestPermission();


### PR DESCRIPTION
TFLite classification example fix permission crash