### PR TITLE
fix deprecations: tfLite.setNumThreads -> tfLiteOptions.setNumThreads

### DIFF
--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
@@ -73,6 +73,8 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
   private ByteBuffer imgData;
 
   private Interpreter tfLite;
+  /** Options for configuring the Interpreter. */
+  private final Interpreter.Options tfLiteOptions = new Interpreter.Options();
 
   private TFLiteObjectDetectionAPIModel() {}
 
@@ -120,7 +122,8 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
     d.inputSize = inputSize;
 
     try {
-      d.tfLite = new Interpreter(loadModelFile(assetManager, modelFilename));
+      d.tfLiteOptions.setNumThreads(NUM_THREADS);
+      d.tfLite = new Interpreter(loadModelFile(assetManager, modelFilename), d.tfLiteOptions);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -137,7 +140,7 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
     d.imgData.order(ByteOrder.nativeOrder());
     d.intValues = new int[d.inputSize * d.inputSize];
 
-    d.tfLite.setNumThreads(NUM_THREADS);
+    // d.tfLite.setNumThreads(NUM_THREADS);
     d.outputLocations = new float[1][NUM_DETECTIONS][4];
     d.outputClasses = new float[1][NUM_DETECTIONS];
     d.outputScores = new float[1][NUM_DETECTIONS];
@@ -230,11 +233,17 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
   public void close() {}
 
   public void setNumThreads(int num_threads) {
-    if (tfLite != null) tfLite.setNumThreads(num_threads);
+    // if (tfLite != null) tfLite.setNumThreads(num_threads);
+    if (tfLiteOptions != null) {
+      tfLiteOptions.setNumThreads(num_threads);
+    }
   }
 
   @Override
   public void setUseNNAPI(boolean isChecked) {
-    if (tfLite != null) tfLite.setUseNNAPI(isChecked);
+    // if (tfLite != null) tfLite.setUseNNAPI(isChecked);
+    if (tfLiteOptions != null) {
+      tfLiteOptions.setUseNNAPI(isChecked);
+    }
   }
 }


### PR DESCRIPTION
The latest tfLite does not allow to directly set the numThreads to the interpreter.
Instead, the numThreads must be set to an optionsObject that has to be passed while creating the tflite interpreter.

The changes are
1. instantiation of tfLite interpreter passing the options object
2. the num threads is set to the options object