### PR TITLE
Make distributed tensorflow doc work

### DIFF
--- a/community/en/docs/deploy/distributed.md
+++ b/community/en/docs/deploy/distributed.md
@@ -64,7 +64,7 @@ constructor.  For example:
     <td><pre>
 tf.train.ClusterSpec({"local": ["localhost:2222", "localhost:2223"]})
 </pre></td>
-<td><code>/job:local/task:0<br/>/job:local/task:1</code></td>
+    <td><code>/job:local/task:0</code><br/><code>/job:local/task:1</code></td>
   </tr>
   <tr>
     <td><pre>


### PR DESCRIPTION
The second column of first row for tf.train.ClusterSpec construction is misplaced, which may lead to some confusion to new users.