### PR TITLE
fix bug of NPE

### DIFF
--- a/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/LegacyCameraConnectionFragment.java
+++ b/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/LegacyCameraConnectionFragment.java
@@ -151,7 +151,9 @@ public class LegacyCameraConnectionFragment extends Fragment {
     // the SurfaceTextureListener).
 
     if (textureView.isAvailable()) {
-      camera.startPreview();
+      if (camera != null) {
+        camera.startPreview();
+      }
     } else {
       textureView.setSurfaceTextureListener(surfaceTextureListener);
     }


### PR DESCRIPTION
05-20 16:07:32.433  4529  4529 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.Camera.startPreview()' on a null object reference
05-20 16:07:32.433  4529  4529 E AndroidRuntime:        at org.tensorflow.lite.examples.classification.LegacyCameraConnectionFragment.onResume(LegacyCameraConnectionFragment.java:154)