### PR TITLE
fixed index out of bounds in recognizeImage method

### DIFF
--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
@@ -207,12 +207,15 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
       // in label file and class labels start from 1 to number_of_classes+1,
       // while outputClasses correspond to class index from 0 to number_of_classes
       int labelOffset = 1;
-      recognitions.add(
-          new Recognition(
-              "" + i,
-              labels.get((int) outputClasses[0][i] + labelOffset),
-              outputScores[0][i],
-              detection));
+      int labelIndex = (int) outputClasses[0][i] + labelOffset;
+      if(labelIndex >= 0 && labelIndex < labels.size()) {
+        recognitions.add(
+                new Recognition(
+                        "" + i,
+                        labels.get(labelIndex),
+                        outputScores[0][i],
+                        detection));
+      }
     }
     Trace.endSection(); // "recognizeImage"
     return recognitions;


### PR DESCRIPTION
While trying to run model with 2 classes i've been getting index out of bounds in label list. Sometimes array outputClasses may contains negative values. It happens only with custom models that have small amount of labels.