### PR TITLE
[Udacity course l06] Fixed wrong example object usage and format_imag…

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l06c02_exercise_flowers_with_transfer_learning.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l06c02_exercise_flowers_with_transfer_learning.ipynb
@@ -254,7 +254,7 @@
       "outputs": [],
       "source": [
         "for i, example in enumerate(training_set.take(5)):\n",
-        "  print('Image {} shape: {} label: {}'.format(i+1, example[0].shape, example[1]))"
+        "  print('Image {} shape: {} label: {}'.format(i+1, example['image'][0].shape, example['label']))"
       ]
     },
     {
@@ -281,7 +281,7 @@
       "source": [
         "IMAGE_RES = \n",
         "\n",
-        "def format_image(image, label):\n",
+        "def format_image(data):\n",
         "  \n",
         "  return image, label\n",
         "\n",

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l06c03_exercise_flowers_with_transfer_learning_solution.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l06c03_exercise_flowers_with_transfer_learning_solution.ipynb
@@ -261,7 +261,7 @@
       "outputs": [],
       "source": [
         "for i, example in enumerate(training_set.take(5)):\n",
-        "  print('Image {} shape: {} label: {}'.format(i+1, example[0].shape, example[1]))"
+        "  print('Image {} shape: {} label: {}'.format(i+1, example['image'][0].shape, example['label']))"
       ]
     },
     {
@@ -288,8 +288,9 @@
       "source": [
         "IMAGE_RES = 224\n",
         "\n",
-        "def format_image(image, label):\n",
-        "  image = tf.image.resize(image, (IMAGE_RES, IMAGE_RES))/255.0\n",
+        "def format_image(data):\n",
+        "  image = tf.image.resize(data['image'], (IMAGE_RES, IMAGE_RES))/255.0\n",
+        "  label = data['label']\n",
         "  return  image, label\n",
         "\n",
         "BATCH_SIZE = 32\n",


### PR DESCRIPTION
In the Udacity "Intro to TensorFlow" course, lesson 6 Colab, found a number of bugs in the data preprocessing section, specifically when accessing the training set's elements.