### PR TITLE
Fixed ArrayIndexOutOfBoundsException

### DIFF
--- a/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/CameraActivity.java
+++ b/lite/examples/image_classification/android/app/src/main/java/org/tensorflow/lite/examples/classification/CameraActivity.java
@@ -378,8 +378,7 @@ public abstract class CameraActivity extends AppCompatActivity
       final int requestCode, final String[] permissions, final int[] grantResults) {
     if (requestCode == PERMISSIONS_REQUEST) {
       if (grantResults.length > 0
-          && grantResults[0] == PackageManager.PERMISSION_GRANTED
-          && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+          && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
         setFragment();
       } else {
         requestPermission();


### PR DESCRIPTION
When installing the tensorflow-lite image-classification example on android for the first time, an `ArrayIndexOutOfBoundsException` occurs:
`E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.tensorflow.lite.examples.classification, PID: 17165
    java.lang.RuntimeException: Failure delivering result ResultInfo{who=@android:requestPermissions:, request=1, result=-1, data=Intent { act=android.content.pm.action.REQUEST_PERMISSIONS (has extras) }} to activity {org.tensorflow.lite.examples.classification/org.tensorflow.lite.examples.classification.ClassifierActivity}: java.lang.ArrayIndexOutOfBoundsException: length=1; index=1
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4538)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:4580)
        at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:49)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1934)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6940)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:537)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: java.lang.ArrayIndexOutOfBoundsException: length=1; index=1
        at org.tensorflow.lite.examples.classification.CameraActivity.onRequestPermissionsResult(CameraActivity.java:380)
        at android.app.Activity.dispatchRequestPermissionsResult(Activity.java:7636)
        at android.app.Activity.dispatchActivityResult(Activity.java:7486)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4531)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:4580) 
        at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:49) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1934) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:193) 
        at android.app.ActivityThread.main(ActivityThread.java:6940) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:537) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)`