### PR TITLE
Fix instance normalization scale initializer

### DIFF
--- a/tensorflow_examples/models/pix2pix/pix2pix.py
+++ b/tensorflow_examples/models/pix2pix/pix2pix.py
@@ -169,7 +169,7 @@ class InstanceNormalization(tf.keras.layers.Layer):
     self.scale = self.add_weight(
         name='scale',
         shape=input_shape[-1:],
-        initializer=tf.random_normal_initializer(0., 0.02),
+        initializer=tf.random_normal_initializer(1., 0.02),
         trainable=True)
 
     self.offset = self.add_weight(


### PR DESCRIPTION
As per [previous discussion](https://github.com/tensorflow/examples/commit/f28b124a2aabdc58a66f5f12904824fd110599a2#r34756231), the scale parameter of the instance normalization should be initialized with mean `1.0` instead of `0.0`.