### PR TITLE
fix for new way to initialize IntepreterOptions

### DIFF
--- a/lite/examples/object_detection/ios/ObjectDetection/ModelDataHandler/ModelDataHandler.swift
+++ b/lite/examples/object_detection/ios/ObjectDetection/ModelDataHandler/ModelDataHandler.swift
@@ -97,7 +97,7 @@ class ModelDataHandler: NSObject {
 
     // Specify the options for the `Interpreter`.
     self.threadCount = threadCount
-    var options = Interpreter.Options()
+    var options = InterpreterOptions.init()
     options.threadCount = threadCount
     do {
       // Create the `Interpreter`.


### PR DESCRIPTION
This fixes a build error that occurs on the master branch.