### PR TITLE
Fix issues with not imported tensorflow

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c03_moving_average.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c03_moving_average.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c04_time_windows.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c04_time_windows.ipynb
@@ -111,7 +111,7 @@
       },
       "outputs": [],
       "source": [
-        "tf.enable_v2_behavior()"
+        "import tensorflow as tf"
       ]
     },
     {

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c05_forecasting_with_machine_learning.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c05_forecasting_with_machine_learning.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c06_forecasting_with_rnn.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c06_forecasting_with_rnn.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c07_forecasting_with_stateful_rnn.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c07_forecasting_with_stateful_rnn.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c08_forecasting_with_lstm.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c08_forecasting_with_lstm.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]

--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c09_forecasting_with_cnn.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l08c09_forecasting_with_cnn.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
-        "tf.enable_v2_behavior()\n",
+        "import tensorflow as tf\n",
         "\n",
         "keras = tf.keras"
       ]


### PR DESCRIPTION
Seems like in original version they used `compat.v2` and after it was refactored to tf2, but somehow left broken.

As a result current live version is broken - no import of tensorflow. I removed `enable_v2_behavior` since colab does support tf2 with magic above.

PS: feels like I am the first one checking these notebooks 🙈 