### PR TITLE
Update the resize dimension for TestActivity

### DIFF
--- a/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/TestActivity.kt
+++ b/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/TestActivity.kt
@@ -30,7 +30,7 @@ import org.tensorflow.lite.examples.posenet.lib.Posenet as Posenet
 class TestActivity : AppCompatActivity() {
   /** Returns a resized bitmap of the drawable image.    */
   private fun drawableToBitmap(drawable: Drawable): Bitmap {
-    val bitmap = Bitmap.createBitmap(257, 353, Bitmap.Config.ARGB_8888)
+    val bitmap = Bitmap.createBitmap(257, 257, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)
 
     drawable.setBounds(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
The Model which you are using in this example takes input 257x257(https://github.com/tensorflow/examples/blob/master/lite/examples/posenet/android/posenet/download.gradle#L2) image whereas it is 257x353 here. Which was throwing `java.lang.IllegalArgumentException: Cannot convert between a TensorFlowLite buffer with 792588 bytes and a ByteBuffer with 1088652 bytes` error.