### PR TITLE
iterate through less detections if returned less than max amount

### DIFF
--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/tflite/TFLiteObjectDetectionAPIModel.java
@@ -37,6 +37,8 @@ import java.util.Vector;
 import org.tensorflow.lite.Interpreter;
 import org.tensorflow.lite.examples.detection.env.Logger;
 
+import static java.lang.Math.min;
+
 /**
  * Wrapper for frozen detection models trained using the Tensorflow Object Detection API:
  * github.com/tensorflow/models/tree/master/research/object_detection
@@ -196,7 +198,7 @@ public class TFLiteObjectDetectionAPIModel implements Classifier {
     // Show the best detections.
     // after scaling them back to the input size.
     final ArrayList<Recognition> recognitions = new ArrayList<>(NUM_DETECTIONS);
-    for (int i = 0; i < NUM_DETECTIONS; ++i) {
+    for (int i = 0; i < min(numDetections[0], NUM_DETECTIONS); ++i) {
       final RectF detection =
           new RectF(
               outputLocations[0][i][1] * inputSize,


### PR DESCRIPTION
In tflite models other than the one provided in the example (e.g. [ssd_mobilenet_v1_coco](http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz)), there may be less detections returned than `NUM_DETECTIONS`. When less detections are provided, garbage float values are passed back, causing the example to crash or return false predictions. This is prevented if you use the returned `numDetections` value to help control the number of detections to use. 

fixes https://github.com/tensorflow/tensorflow/issues/22278 and https://github.com/tensorflow/tensorflow/issues/22106.