### PR TITLE
Fix broken link in README.md

### DIFF
--- a/lite/examples/image_classification/android/README.md
+++ b/lite/examples/image_classification/android/README.md
@@ -15,7 +15,7 @@ model, select the thread count, and decide whether to run on CPU, GPU, or via
 
 These instructions walk you through building and
 running the demo on an Android device. For an explanation of the source, see
-[TensorFlow Lite Android image classification example](https://www.tensorflow.org/lite/models/image_classification/android).
+[TensorFlow Lite Android image classification example](EXPLORE_THE_CODE.md).
 
 <!-- TODO(b/124116863): Add app screenshot. -->
 


### PR DESCRIPTION
"TensorFlow Lite Android image classification example" links to a missing tensorflow.org page and returns a 404 error. The intended resource can be found as a markdown file in this repository and the link has been updated.