### PR TITLE
Modified spacing and comments in interpreter code in order to show it in codelabs

### DIFF
--- a/lite/codelabs/digit_classifier/android/finish/app/src/main/java/org/tensorflow/lite/codelabs/digitclassifier/DigitClassifier.kt
+++ b/lite/codelabs/digit_classifier/android/finish/app/src/main/java/org/tensorflow/lite/codelabs/digitclassifier/DigitClassifier.kt
@@ -56,11 +56,9 @@ class DigitClassifier(private val context: Context) {
   private fun initializeInterpreter() {
     // TODO: Load the TF Lite model from file and initialize an interpreter.
 
-    // Load the TF Lite model from asset folder.
+    // Load the TF Lite model from asset folder and initialize TF Lite Interpreter with NNAPI enabled.
     val assetManager = context.assets
     val model = loadModelFile(assetManager, "mnist.tflite")
-
-    // Initialize TF Lite Interpreter with NNAPI enabled.
     val options = Interpreter.Options()
     options.setUseNNAPI(true)
     val interpreter = Interpreter(model, options)


### PR DESCRIPTION
Possibly Fixes [#37780](https://github.com/tensorflow/tensorflow/issues/37780).  
I have observed in tensorflow code repo that the doc is built from the docstring in code itself. I assume the same thing is here too. That's why as per my understanding I have changed the code in order to show it in codelab.  
@mihaimaruseac and @MarkDaoust , Please review this one.