### PR TITLE
[DigitClassifier][iOS] Fixed issue where the label is invisible when iPhone is in dark mode

### DIFF
--- a/lite/examples/digit_classifier/ios/DigitClassifier/Info.plist
+++ b/lite/examples/digit_classifier/ios/DigitClassifier/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# Summary

Since the `Result Label`'s text color was set to "Default (Label color)", this caused the text to default to white, which is invisible on a white background.

This forces the app to always use Light mode, regardless of the iPhone settings.

**An alternative fix is to set the text color to 'Dark Text Color' or equivalent, but the Storyboard diff would be messier.**

# Reproduction steps:
1. In iPhone Settings -> Developer: Set 'Dark Appearance' to true
2. View DigitClassifier app

You will see:

<img width="414" alt="Screenshot 2020-03-27 at 10 42 27 PM" src="https://user-images.githubusercontent.com/1586049/77813120-6884a300-707c-11ea-82e7-8a80d0774325.png">

After the fix, you will see:

<img width="418" alt="Screenshot 2020-03-27 at 10 41 13 PM" src="https://user-images.githubusercontent.com/1586049/77813123-6fabb100-707c-11ea-9a0c-351b829d4e00.png">

