### PR TITLE
Fixed bug with spaces in working directory paths

### DIFF
--- a/lite/examples/image_classification/ios/ImageClassification.xcodeproj/project.pbxproj
+++ b/lite/examples/image_classification/ios/ImageClassification.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$SRCROOT/RunScripts/download_models.sh\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"$SRCROOT/RunScripts/download_models.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/lite/examples/image_classification/ios/RunScripts/download_models.sh
+++ b/lite/examples/image_classification/ios/RunScripts/download_models.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODELS_URL="https://storage.googleapis.com/download.tensorflow.org/models/tflite/mobilenet_v1_224_android_quant_2017_11_08.zip"
 DOWNLOADS_DIR=$(mktemp -d)
 
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 download_and_extract() {
   local usage="Usage: download_and_extract URL DIR"

--- a/lite/examples/object_detection/ios/ObjectDetection.xcodeproj/project.pbxproj
+++ b/lite/examples/object_detection/ios/ObjectDetection.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$SRCROOT/RunScripts/download_models.sh\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"$SRCROOT/RunScripts/download_models.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/lite/examples/object_detection/ios/RunScripts/download_models.sh
+++ b/lite/examples/object_detection/ios/RunScripts/download_models.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODELS_URL="https://storage.googleapis.com/download.tensorflow.org/models/tflite/coco_ssd_mobilenet_v1_1.0_quant_2018_06_29.zip"
 DOWNLOADS_DIR=$(mktemp -d)
 
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 download_and_extract() {
   local usage="Usage: download_and_extract URL DIR"

--- a/lite/examples/posenet/ios/PoseNet.xcodeproj/project.pbxproj
+++ b/lite/examples/posenet/ios/PoseNet.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "$SRCROOT/RunScripts/download_models.sh\n";
+			shellScript = "\"$SRCROOT/RunScripts/download_models.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/lite/examples/speech_commands/ios/RunScripts/download_models.sh
+++ b/lite/examples/speech_commands/ios/RunScripts/download_models.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODELS_URL="https://storage.googleapis.com/download.tensorflow.org/models/tflite/conv_actions_tflite.zip"
 DOWNLOADS_DIR=$(mktemp -d)
 
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 download_and_extract() {
   local usage="Usage: download_and_extract URL DIR"

--- a/lite/examples/speech_commands/ios/SpeechCommands.xcodeproj/project.pbxproj
+++ b/lite/examples/speech_commands/ios/SpeechCommands.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/RunScripts/download_models.sh\n";
+			shellScript = "\"$SRCROOT/RunScripts/download_models.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
`$SRCROOT/RunScripts/download_models.sh` has been changed to `"$SRCROOT/RunScripts/download_models.sh"` (with parentheses) in `project.pbxproj`.

Similarly, in the `download_models.sh` script, fixed a "No such file or directory" error in `cd $SCRIPT_DIR` when a space occurs in `pwd`.

```
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"                                          
cd $SCRIPT_DIR                                                                                  
```

Changing `cd $SCRIPT_DIR ` to `cd "$SCRIPT_DIR"` (with parentheses) fixes this issue.