### PR TITLE
Fixed a typo error in README.md

### DIFF
--- a/lite/examples/image_segmentation/ios/README.md
+++ b/lite/examples/image_segmentation/ios/README.md
@@ -7,7 +7,7 @@
 ## Requirements
 
 *  Xcode 10.3 (installed on a Mac machine)
-*  An iOS Simuiator running iOS 12 or above
+*  An iOS Simulator running iOS 12 or above
 *  Xcode command-line tools (run ```xcode-select --install```)
 *  CocoaPods (run ```sudo gem install cocoapods```)
 


### PR DESCRIPTION
There's a typo error in [Requirements of README.md](https://github.com/tensorflow/examples/tree/master/lite/examples/image_segmentation/ios#requirements) of `examples/lite/examples/image_segmentation/ios/`

This PR fixes it by changing Simuiator to Simulator.