### PR TITLE
Fixed application crash issue due to NullPointerException on exit

### DIFF
--- a/lite/examples/model_personalization/android/app/src/main/java/org/tensorflow/lite/examples/transfer/CameraFragment.java
+++ b/lite/examples/model_personalization/android/app/src/main/java/org/tensorflow/lite/examples/transfer/CameraFragment.java
@@ -173,7 +173,13 @@ public class CameraFragment extends Fragment {
           // We don't perform inference when adding samples, since we should be in capture mode
           // at the time, so the inference results are not actually displayed.
           inferenceBenchmark.startStage(imageId, "predict");
-          Prediction[] predictions = tlModel.predict(rgbImage);
+          Prediction[] predictions = null;
+          try {
+            predictions = tlModel.predict(rgbImage, modelImageSize, modelImageSize);
+          }
+          catch (Exception e){
+            return;
+          }
           if (predictions == null) {
             return;
           }


### PR DESCRIPTION
There is an issue when application is closed. `tlModel` is set to null in `onDestroy()` but `InferenceThread` still calls `tlModel.predict` method without checking a null.

> `Prediction[] predictions = tlModel.predict(rgbImage);`

`java.lang.NullPointerException` is thrown at this line. Solved it using try-catch.

