### PR TITLE
Fix loss typo

### DIFF
--- a/community/en/flowers_tf_lite.ipynb
+++ b/community/en/flowers_tf_lite.ipynb
@@ -337,7 +337,7 @@
       "source": [
         "### Compile the model\n",
         "\n",
-        "You must compile the model before training it.  Since there are two classes, use a binary cross-entropy loss."
+        "You must compile the model before training it.  Since there are multiple classes, use a categorical cross-entropy loss."
       ]
     },
     {


### PR DESCRIPTION
The comment mentions binary cross-entropy loss whereas the loss being used is categorical cross entropy