### PR TITLE
Fix the training stage for TF2 API

### DIFF
--- a/community/en/flowers_tf_lite.ipynb
+++ b/community/en/flowers_tf_lite.ipynb
@@ -405,9 +405,11 @@
       "source": [
         "epochs = 10\n",
         "\n",
-        "history = model.fit_generator(train_generator, \n",
+        "history = model.fit(train_generator, \n",
+        "                    steps_per_epoch=len(train_generator), \n",
         "                    epochs=epochs, \n",
-        "                    validation_data=val_generator)"
+        "                    validation_data=val_generator, \n",
+        "                    validation_steps=len(val_generator))"
       ]
     },
     {


### PR DESCRIPTION
Model.fit() in TF2 apparently doesn't check the generator length the way fit_generator() used to in 1.x, so this code would seemingly run forever. Now we need to pass the length as step length for training and validation data.