### PR TITLE
[iOS] Remove unnecessary allocateTensors()

### DIFF
--- a/lite/examples/digit_classifier/ios/DigitClassifier/DigitClassifier.swift
+++ b/lite/examples/digit_classifier/ios/DigitClassifier/DigitClassifier.swift
@@ -99,7 +99,7 @@ class DigitClassifier {
             print("Failed to convert the image buffer to RGB data.")
             return
         }
-        
+
         // Copy the RGB data to the input `Tensor`.
         try self.interpreter.copy(rgbData, toInputAt: 0)
 

--- a/lite/examples/digit_classifier/ios/DigitClassifier/DigitClassifier.swift
+++ b/lite/examples/digit_classifier/ios/DigitClassifier/DigitClassifier.swift
@@ -99,10 +99,7 @@ class DigitClassifier {
             print("Failed to convert the image buffer to RGB data.")
             return
         }
-
-        // Allocate memory for the model's input `Tensor`s.
-        try self.interpreter.allocateTensors()
-
+        
         // Copy the RGB data to the input `Tensor`.
         try self.interpreter.copy(rgbData, toInputAt: 0)
 

--- a/lite/examples/image_segmentation/ios/ImageSegmentation/ImageSegmentator.swift
+++ b/lite/examples/image_segmentation/ios/ImageSegmentation/ImageSegmentator.swift
@@ -217,9 +217,6 @@ class ImageSegmentator {
         preprocessingTime = now.timeIntervalSince(startTime)
         startTime = Date()
 
-        // Allocate memory for the model's input `Tensor`s.
-        try self.interpreter.allocateTensors()
-
         // Copy the RGB data to the input `Tensor`.
         try self.interpreter.copy(rgbData, toInputAt: 0)
 


### PR DESCRIPTION
Hi,

The `AllocateTensors ()` is executed once at initialization.

- DigitClassifier
https://github.com/tensorflow/examples/blob/master/lite/examples/digit_classifier/ios/DigitClassifier/DigitClassifier.swift#L51
- ImageSegmentator
https://github.com/tensorflow/examples/blob/master/lite/examples/image_segmentation/ios/ImageSegmentation/ImageSegmentator.swift#L126

But there was an unnecessary call to `allocateTensor()` elsewhere, so I removed it.

Thanks.