### PR TITLE
Remove not using param on iOS posenet's rgbData method

### DIFF
--- a/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
@@ -120,7 +120,6 @@ extension CVPixelBuffer {
   /// - Returns: The RGB data representation of the image buffer or `nil` if the buffer could not be
   ///     converted.
   func rgbData(
-    byteCount: Int,
     isModelQuantized: Bool
   ) -> Data? {
     CVPixelBufferLockBaseAddress(self, .readOnly)

--- a/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
@@ -109,12 +109,9 @@ extension CVPixelBuffer {
     return result
   }
 
-  /// Returns the RGB `Data` representation of the given image buffer with the specified
-  /// `byteCount`.
+  /// Returns the RGB `Data` representation of the given image buffer.
   ///
   /// - Parameters:
-  ///   - byteCount: The expected byte count for the RGB data calculated using the values that the
-  ///       model was trained on: `batchSize * imageWidth * imageHeight * componentsCount`.
   ///   - isModelQuantized: Whether the model is quantized (i.e. fixed point values rather than
   ///       floating point values).
   /// - Returns: The RGB data representation of the image buffer or `nil` if the buffer could not be

--- a/lite/examples/posenet/ios/PoseNet/ModelDataHandler/ModelDataHandler.swift
+++ b/lite/examples/posenet/ios/PoseNet/ModelDataHandler/ModelDataHandler.swift
@@ -182,7 +182,6 @@ class ModelDataHandler {
       * Model.input.channelSize
     guard
       let inputData = thumbnail.rgbData(
-        byteCount: byteCount,
         isModelQuantized: Model.isQuantized
       )
     else {


### PR DESCRIPTION
Remove `byteCount` parameter on `rgbData` method, because not using now.