### PR TITLE
image scale operator should works for different pixel formats, not limited to BGRA

### DIFF
--- a/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
@@ -26,8 +26,10 @@ extension CVPixelBuffer {
     let imageHeight = CVPixelBufferGetHeight(self)
 
     let pixelBufferType = CVPixelBufferGetPixelFormatType(self)
-
-    assert(pixelBufferType == kCVPixelFormatType_32BGRA)
+    
+    assert(pixelBufferType == kCVPixelFormatType_32BGRA ||
+           pixelBufferType == kCVPixelFormatType_32ARGB ||
+           pixelBufferType == kCVPixelFormatType_32RGBA)
 
     let inputImageRowBytes = CVPixelBufferGetBytesPerRow(self)
     let imageChannels = 4

--- a/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
@@ -26,7 +26,7 @@ extension CVPixelBuffer {
     let imageHeight = CVPixelBufferGetHeight(self)
 
     let pixelBufferType = CVPixelBufferGetPixelFormatType(self)
- 
+
     assert(pixelBufferType == kCVPixelFormatType_32BGRA ||
            pixelBufferType == kCVPixelFormatType_32ARGB)
 

--- a/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
@@ -28,8 +28,7 @@ extension CVPixelBuffer {
     let pixelBufferType = CVPixelBufferGetPixelFormatType(self)
     
     assert(pixelBufferType == kCVPixelFormatType_32BGRA ||
-           pixelBufferType == kCVPixelFormatType_32ARGB ||
-           pixelBufferType == kCVPixelFormatType_32RGBA)
+           pixelBufferType == kCVPixelFormatType_32ARGB)
 
     let inputImageRowBytes = CVPixelBufferGetBytesPerRow(self)
     let imageChannels = 4

--- a/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/object_detection/ios/ObjectDetection/Extensions/CVPixelBufferExtension.swift
@@ -26,7 +26,7 @@ extension CVPixelBuffer {
     let imageHeight = CVPixelBufferGetHeight(self)
 
     let pixelBufferType = CVPixelBufferGetPixelFormatType(self)
-    
+ 
     assert(pixelBufferType == kCVPixelFormatType_32BGRA ||
            pixelBufferType == kCVPixelFormatType_32ARGB)
 


### PR DESCRIPTION
when selecting image from iPhone gallery, we got ARGB images, this change relax pixel format limit in the preprocess step(CVPixelBuffer::resize()) for supporting such image.