### PR TITLE
Fix bug in android speech_commands average score calculation, add unit test

### DIFF
--- a/lite/examples/speech_commands/android/app/build.gradle
+++ b/lite/examples/speech_commands/android/app/build.gradle
@@ -47,4 +47,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'org.tensorflow:tensorflow-lite:2.2.0'
+    testImplementation 'junit:junit:4.12'
+
 }

--- a/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
+++ b/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
@@ -17,7 +17,7 @@
 package org.tensorflow.lite.examples.speech;
 
 import android.util.Log;
-import android.util.Pair;
+import androidx.core.util.Pair;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -123,14 +123,8 @@ public class RecognizeCommands {
       }
     }
 
-    // Add the latest results to the head of the queue.
-    previousResults.addLast(new Pair<Long, float[]>(currentTimeMS, currentResults));
-
-    // Prune any earlier results that are too old for the averaging window.
-    final long timeLimit = currentTimeMS - averageWindowDurationMs;
-    while (previousResults.getFirst().first < timeLimit) {
-      previousResults.removeFirst();
-    }
+    /// refresh previous results buffer by adding new results and removing out of date results
+    previousResults = RefreshPreviousResultsBuffer(previousResults, averageWindowDurationMs, currentResults, currentTimeMS);
 
     howManyResults = previousResults.size();
 
@@ -193,4 +187,22 @@ public class RecognizeCommands {
     }
     return new RecognitionResult(currentTopLabel, currentTopScore, isNewCommand);
   }
+
+  public static Deque<Pair<Long, float[]>> RefreshPreviousResultsBuffer(Deque<Pair<Long, float[]>> previousResultsDeque, long averageWindowDurationMs, float[] currentResults, long currentTimeMS) {
+
+    // Add the latest results to the head of the queue.
+    // Use clone to set by value, rather than reference, preventing new result overwriting old values
+    previousResultsDeque.addLast(new Pair<Long, float[]>(currentTimeMS, currentResults.clone()));
+
+    // Prune any earlier results that are too old for the averaging window.
+    final long timeLimit = currentTimeMS - averageWindowDurationMs;
+    while (previousResultsDeque.getFirst().first < timeLimit) {
+
+      previousResultsDeque.removeFirst();
+    }
+
+    return previousResultsDeque;
+  }
+
+
 }

--- a/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
+++ b/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
@@ -124,7 +124,9 @@ public class RecognizeCommands {
     }
 
     /// refresh previous results buffer by adding new results and removing out of date results
-    previousResults = RefreshPreviousResultsBuffer(previousResults, averageWindowDurationMs, currentResults, currentTimeMS);
+    previousResults =
+        RefreshPreviousResultsBuffer(
+            previousResults, averageWindowDurationMs, currentResults, currentTimeMS);
 
     howManyResults = previousResults.size();
 
@@ -188,10 +190,15 @@ public class RecognizeCommands {
     return new RecognitionResult(currentTopLabel, currentTopScore, isNewCommand);
   }
 
-  public static Deque<Pair<Long, float[]>> RefreshPreviousResultsBuffer(Deque<Pair<Long, float[]>> previousResultsDeque, long averageWindowDurationMs, float[] currentResults, long currentTimeMS) {
+  public static Deque<Pair<Long, float[]>> RefreshPreviousResultsBuffer(
+      Deque<Pair<Long, float[]>> previousResultsDeque,
+      long averageWindowDurationMs,
+      float[] currentResults,
+      long currentTimeMS) {
 
     // Add the latest results to the head of the queue.
-    // Use clone to set by value, rather than reference, preventing new result overwriting old values
+    // Use clone to set by value, rather than reference, preventing new result overwriting old
+    // values
     previousResultsDeque.addLast(new Pair<Long, float[]>(currentTimeMS, currentResults.clone()));
 
     // Prune any earlier results that are too old for the averaging window.
@@ -203,6 +210,4 @@ public class RecognizeCommands {
 
     return previousResultsDeque;
   }
-
-
 }

--- a/lite/examples/speech_commands/android/app/src/test/java/org/tensorflow/lite/examples/speech/RecognizeCommandsTest.java
+++ b/lite/examples/speech_commands/android/app/src/test/java/org/tensorflow/lite/examples/speech/RecognizeCommandsTest.java
@@ -1,0 +1,36 @@
+package org.tensorflow.lite.examples.speech;
+
+import androidx.core.util.Pair;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+public class RecognizeCommandsTest {
+    Deque<Pair<Long, float[]>> workingDeque = new ArrayDeque<Pair<Long, float[]>>();
+    float[] ephemeralResult = new float[3];
+
+    @Test
+    public void recogniseCommands_RefreshPreviousResultsBuffer_CorrectlyAveragesPredictions() {
+
+        for (int i = 0; i < 3; i++) {
+            Long dummyTime = (long) (i * 10);
+            //fill dummy data to simulate the updating of predictions by tfLite.run
+            Arrays.fill(ephemeralResult, (float) i);
+
+            workingDeque = RecognizeCommands.RefreshPreviousResultsBuffer(
+                    workingDeque,
+                    100L,
+                    ephemeralResult,
+                    dummyTime
+            );
+        }
+
+        // Assert that the final value of the result in the Deque did not overwrite the first value added
+        Assert.assertFalse(workingDeque.getFirst().second.equals(workingDeque.getLast().second));
+    }
+
+}

--- a/lite/examples/speech_commands/android/app/src/test/java/org/tensorflow/lite/examples/speech/RecognizeCommandsTest.java
+++ b/lite/examples/speech_commands/android/app/src/test/java/org/tensorflow/lite/examples/speech/RecognizeCommandsTest.java
@@ -10,27 +10,24 @@ import java.util.Arrays;
 import java.util.Deque;
 
 public class RecognizeCommandsTest {
-    Deque<Pair<Long, float[]>> workingDeque = new ArrayDeque<Pair<Long, float[]>>();
-    float[] ephemeralResult = new float[3];
+  Deque<Pair<Long, float[]>> workingDeque = new ArrayDeque<Pair<Long, float[]>>();
+  float[] ephemeralResult = new float[3];
 
-    @Test
-    public void recogniseCommands_RefreshPreviousResultsBuffer_CorrectlyAveragesPredictions() {
+  @Test
+  public void recogniseCommands_RefreshPreviousResultsBuffer_CorrectlyAveragesPredictions() {
 
-        for (int i = 0; i < 3; i++) {
-            Long dummyTime = (long) (i * 10);
-            //fill dummy data to simulate the updating of predictions by tfLite.run
-            Arrays.fill(ephemeralResult, (float) i);
+    for (int i = 0; i < 3; i++) {
+      Long dummyTime = (long) (i * 10);
+      // fill dummy data to simulate the updating of predictions by tfLite.run
+      Arrays.fill(ephemeralResult, (float) i);
 
-            workingDeque = RecognizeCommands.RefreshPreviousResultsBuffer(
-                    workingDeque,
-                    100L,
-                    ephemeralResult,
-                    dummyTime
-            );
-        }
-
-        // Assert that the final value of the result in the Deque did not overwrite the first value added
-        Assert.assertFalse(workingDeque.getFirst().second.equals(workingDeque.getLast().second));
+      workingDeque =
+          RecognizeCommands.RefreshPreviousResultsBuffer(
+              workingDeque, 100L, ephemeralResult, dummyTime);
     }
 
+    // Assert that the final value of the result in the Deque did not overwrite the first value
+    // added
+    Assert.assertFalse(workingDeque.getFirst().second.equals(workingDeque.getLast().second));
+  }
 }


### PR DESCRIPTION
Bug fix to allow averaging logic to work correctly in the speech_commands demo. It should result in a significant improvement in predictive accuracy for the Android app.

Previous logic added a reference to the result array to the Deque (as opposed
to the value of the result array). When a new result was added to the Deque,
all previous results were updated to this value (because they were references)
meaning the averaging operation was performed on a Deque of identical arrays -
effectively just returning the final value added to the Deque, rather than an
average of previous results.

The code change extracts this updating logic to a function which is independently
testable, and modifies the logic to add the array value rather than a reference.