### PR TITLE
Fix bug in Android speech_commands average score calculation

### DIFF
--- a/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
+++ b/lite/examples/speech_commands/android/app/src/main/java/org/tensorflow/lite/examples/speech/RecognizeCommands.java
@@ -124,7 +124,7 @@ public class RecognizeCommands {
     }
 
     // Add the latest results to the head of the queue.
-    previousResults.addLast(new Pair<Long, float[]>(currentTimeMS, currentResults));
+    previousResults.addLast(new Pair<Long, float[]>(currentTimeMS, currentResults.clone()));
 
     // Prune any earlier results that are too old for the averaging window.
     final long timeLimit = currentTimeMS - averageWindowDurationMs;


### PR DESCRIPTION
**Same fix as https://github.com/tensorflow/examples/pull/232 but without unit test coverage** 

Previous logic added a reference to the result array to the Deque (as opposed
to the value of the result array). When a new result was added to the Deque,
all previous results were updated to this value (because they were references)
meaning the averaging operation was performed on a Deque of identical arrays -
effectively just returning the final value added to the Deque, rather than an
average of previous results.

The code change extracts this updating logic to a function which is independently
testable, and modifies the logic to add the array value rather than a reference.

