### PR TITLE
Fixed typos in position_encoding.ipynb

### DIFF
--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -70,7 +70,7 @@
         "\n",
         "To give the model access to this information the transformer architecture uses adda a position encoding to the input.\n",
         "\n",
-        "This endocing is a vector of sines and cosines at each position, where each sine-cosine pair rotates at a different frequency.  \n",
+        "This encoding is a vector of sines and cosines at each position, where each sine-cosine pair rotates at a different frequency.  \n",
         "\n",
         "Nearby locations will have similar position-encoding vectors."
       ]

--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -66,7 +66,7 @@
       "source": [
         "See [this notebook](https://github.com/site/en/r2/tutorials/sequences/transformer.ipynb) for a walk-through of full transformer implementation.\n",
         "\n",
-        "The transformer architecture uses stacked attention layers in place of CNNs or RNNs. This makes it easy to learn long-range dependencise but it contains no built in information about the relative positions of items in a sequence. \n",
+        "The transformer architecture uses stacked attention layers in place of CNNs or RNNs. This makes it easy to learn long-range dependencies but it contains no built in information about the relative positions of items in a sequence. \n",
         "\n",
         "To give the model access to this information the transformer architecture uses adda a position encoding to the input.\n",
         "\n",

--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -295,7 +295,7 @@
         "id": "xH-sU6mzmjXI"
       },
       "source": [
-        "Regardless of how you compare the vecors, they are most similar 20, and clearly diverge as you move away: "
+        "Regardless of how you compare the vectors, they are most similar 20, and clearly diverge as you move away: "
       ]
     },
     {

--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -68,7 +68,7 @@
         "\n",
         "The transformer architecture uses stacked attention layers in place of CNNs or RNNs. This makes it easy to learn long-range dependencies but it contains no built in information about the relative positions of items in a sequence. \n",
         "\n",
-        "To give the model access to this information the transformer architecture uses adda a position encoding to the input.\n",
+        "To give the model access to this information the transformer architecture adds a position encoding to the input.\n",
         "\n",
         "This encoding is a vector of sines and cosines at each position, where each sine-cosine pair rotates at a different frequency.  \n",
         "\n",


### PR DESCRIPTION
I fixed various typos in the textual description of the notebook.