### PR TITLE
fix: MAX_SAMPLES match description to code

### DIFF
--- a/community/en/transformer_chatbot.ipynb
+++ b/community/en/transformer_chatbot.ipynb
@@ -219,7 +219,7 @@
       "source": [
         "### Load and preprocess data\n",
         "\n",
-        "To keep this example simple and fast, we are limiting the maximum number of training samples to`MAX_SAMPLES=25000` and the maximum length of the sentence to be `MAX_LENGTH=40`.\n",
+        "To keep this example simple and fast, we are limiting the maximum number of training samples to`MAX_SAMPLES=50000` and the maximum length of the sentence to be `MAX_LENGTH=40`.\n",
         "\n",
         "We preprocess our dataset in the following order:\n",
         "* Extract `MAX_SAMPLES` conversation pairs into list of `questions` and `answers.\n",


### PR DESCRIPTION
The code uses MAX_SAMPLES=50000 but the description uses MAX_SAMPLES=25000.
This commit syncs the two, favouring the code as the correct value.