### PR TITLE
In the Udacity course tf4dl: Changed 2 text boxes to match actual prediction

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l03c01_classifying_images_of_clothing.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l03c01_classifying_images_of_clothing.ipynb
@@ -656,7 +656,7 @@
         "id": "E51yS7iCCaXO"
       },
       "source": [
-        "So the model is most confident that this image is a shirt, or `class_names[6]`. And we can check the test label to see this is correct:"
+        "So the model is most confident that this image is a coat, or `class_names[4]`. And we can check the test label to see this is correct:"
       ]
     },
     {
@@ -896,7 +896,7 @@
         "id": "YFc2HbEVCaXd"
       },
       "source": [
-        "And, as before, the model predicts a label of 6 (shirt)."
+        "And, as before, the model predicts a label of 4 (coat)."
       ]
     },
     {


### PR DESCRIPTION
The markdown cells in l03c01_classifying_images_of_clothing.ipynb say that the model predicts the label 6, but when you run the code it correctly predicts the label 4. Maybe the order of the test data has changed since the notebook was written. So I just changed the text in the markdown cells to match the actual prediction that is made by the model.