### PR TITLE
Removed `TFLiteObjectDetectionAPIModel.java` set `labelOffset` to `0` instruction from README

### DIFF
--- a/lite/examples/object_detection/android/README.md
+++ b/lite/examples/object_detection/android/README.md
@@ -79,7 +79,7 @@ bazel run //tensorflow/lite/tools:visualize \
 ```
 
 * Get `labelmap.txt` from the second column of **[class-descriptions-boxable](https://storage.googleapis.com/openimages/2018_04/class-descriptions-boxable.csv)**.
-* In `DetectorActivity.java` set `TF_OD_API_IS_QUANTIZED` to `false` and in `TFLiteObjectDetectionAPIModel.java` set `labelOffset` to `0`.
+* In `DetectorActivity.java` set `TF_OD_API_IS_QUANTIZED` to `false`.
 
 
 ### Additional Note


### PR DESCRIPTION
Removed "and in `TFLiteObjectDetectionAPIModel.java` set `labelOffset` to `0`" from lite/examples/object_detection/android/README.md as this no longer exists in current android java code.

`TFLiteObjectDetectionAPIModel.java` diff from last commit, 
https://github.com/tensorflow/examples/commit/de42482b453de6f7b6488203b20e7eec61ee722e#diff-0cf980453f18b3cc1368f8eb16a803f9