### PR TITLE
Wrong inputs in styletransfer/ImageUtils function calls.

### DIFF
--- a/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/ImageUtils.kt
+++ b/lite/examples/style_transfer/android/app/src/main/java/org/tensorflow/lite/examples/styletransfer/ImageUtils.kt
@@ -136,7 +136,7 @@ abstract class ImageUtils {
         RectF(
           0f, 0f,
           targetBmp.width.toFloat(),
-          targetBmp.width.toFloat()
+          targetBmp.height.toFloat()
         ),
         RectF(
           0f, 0f,
@@ -148,7 +148,7 @@ abstract class ImageUtils {
       return Bitmap.createBitmap(
         targetBmp, 0, 0,
         targetBmp.width,
-        targetBmp.width, matrix, true
+        targetBmp.height, matrix, true
       )
     }
 


### PR DESCRIPTION
RectF declaration ([docs](https://developer.android.com/reference/android/graphics/RectF#RectF(float,%20float,%20float,%20float))) -
   ``` public RectF (float left, float top, float right, float bottom)```
Function call to RectF inputs image width at both 'right' and 'bottom' parameters.

createBitmap declaration ([docs](https://developer.android.com/reference/android/graphics/Bitmap#createBitmap(android.graphics.Bitmap,%20int,%20int,%20int,%20int,%20android.graphics.Matrix,%20boolean))) -
   ``` public static Bitmap createBitmap (Bitmap source, int x, int y, int width, int height, Matrix m, boolean filter) ```
Function call to createBitmap inputs image width at the place of 'height'. 

Worked when image width equals image height but may throw ```IllegalArgumentException: y + height must be <= bitmap.height() ``` otherwise.