### PR TITLE
no matching distribution for 2.4.0.dev20200810

### DIFF
--- a/tensorflow_examples/lite/model_maker/requirements.txt
+++ b/tensorflow_examples/lite/model_maker/requirements.txt
@@ -8,4 +8,4 @@ fire
 flatbuffers==1.12
 absl-py
 tflite-support==0.1.0rc3.dev2
-tf-nightly==2.4.0.dev20200810
+tf-nightly==2.4.0.dev20201012


### PR DESCRIPTION
there is no matching distribution for tf-nightly==2.4.0.dev20200810 and that causes the installation to fail.