### PR TITLE
Rename Raspbian to Raspberry Pi OS

### DIFF
--- a/lite/examples/image_classification/raspberry_pi/README.md
+++ b/lite/examples/image_classification/raspberry_pi/README.md
@@ -15,7 +15,7 @@ camera input.
 
 Before you begin, you need to [set up your Raspberry Pi](
 https://projects.raspberrypi.org/en/projects/raspberry-pi-setting-up) with
-Raspbian (preferably updated to Buster).
+Raspberry Pi OS (preferably updated to Buster).
 
 You also need to [connect and configure the Pi Camera](
 https://www.raspberrypi.org/documentation/configuration/camera.md).

--- a/lite/examples/object_detection/raspberry_pi/README.md
+++ b/lite/examples/object_detection/raspberry_pi/README.md
@@ -19,7 +19,7 @@ the Coral USB Accelerator, which increases the inference speed by ~10x.
 
 Before you begin, you need to [set up your Raspberry Pi](
 https://projects.raspberrypi.org/en/projects/raspberry-pi-setting-up) with
-Raspbian (preferably updated to Buster).
+Raspberry Pi OS (preferably updated to Buster).
 
 You also need to [connect and configure the Pi Camera](
 https://www.raspberrypi.org/documentation/configuration/camera.md).


### PR DESCRIPTION
This May, Raspbian was renamed to Raspberry Pi OS, as visible on the [official Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/raspberry-pi-os/). In order to maintain consistency and reduce confusion for new users, we should replace Raspbian with Raspberry Pi OS in our docs wherever it makes sense.

Also see https://github.com/tensorflow/tensorflow/pull/44102 .