### PR TITLE
Fix broken link pointing to transformers.ipynb

### DIFF
--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -64,7 +64,7 @@
         "id": "ZPoPd7GbdK0G"
       },
       "source": [
-        "See [this notebook](https://github.com/site/en/r2/tutorials/sequences/transformer.ipynb) for a walk-through of full transformer implementation.\n",
+        "See [this notebook](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/text/transformer.ipynb) for a walk-through of full transformer implementation.\n",
         "\n",
         "The transformer architecture uses stacked attention layers in place of CNNs or RNNs. This makes it easy to learn long-range dependencies but it contains no built in information about the relative positions of items in a sequence. \n",
         "\n",


### PR DESCRIPTION
Previous link appears to lead to nowhere

Closes https://github.com/tallamjr/tfexamples/issues/1

	modified:   community/en/position_encoding.ipynb