### PR TITLE
Update position_encoding.ipynb

### DIFF
--- a/community/en/position_encoding.ipynb
+++ b/community/en/position_encoding.ipynb
@@ -225,9 +225,12 @@
       },
       "outputs": [],
       "source": [
-        "sines = np.sin(angle_rads)\n",
-        "cosines = np.cos(angle_rads)\n",
-        "pos_encoding = np.concatenate([sines, cosines], axis=-1)"
+        "sines = np.sin(angle_rads[:, 0::2])\n",
+        "cosines = np.cos(angle_rads[:, 1::2])\n",
+        "angle_rads2 = np.zeros(angle_rads.shape)\n",
+        "angle_rads2[:, 0::2] = sines\n",
+        "angle_rads2[:, 1::2] = cosines\n",
+        "pos_encoding = angle_rads2[np.newaxis, ...]"
       ]
     },
     {


### PR DESCRIPTION
If you use `np.concatenate([sines, cosines], axis=-1)`, all of the cosines come after all of the sines, just like `[sin(), sin(), sin(), ..., cos(), cos(), cos()]`. But what we expect is `[sin(), cos(), sin(), cos(), ..., sin(), cos()]`, so it should be corrected as proposed.
You can check that by the example you wrote below. If you run the code `plt.pcolormesh(pos_encoding, ...`, you don't get what you expected.