### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_examples/models/densenet/densenet.py
+++ b/tensorflow_examples/models/densenet/densenet.py
@@ -116,7 +116,7 @@ def calc_from_integer(depth, num_blocks, layers_per_block):
 class ConvBlock(tf.keras.Model):
   """Convolutional Block consisting of (batchnorm->relu->conv).
 
-  Arguments:
+  Args:
     num_filters: number of filters passed to a convolutional layer.
     data_format: "channels_first" or "channels_last"
     bottleneck: if True, then a 1x1 Conv is performed followed by 3x3 Conv.
@@ -168,7 +168,7 @@ class ConvBlock(tf.keras.Model):
 class TransitionBlock(tf.keras.Model):
   """Transition Block to reduce the number of features.
 
-  Arguments:
+  Args:
     num_filters: number of filters passed to a convolutional layer.
     data_format: "channels_first" or "channels_last"
     weight_decay: weight decay
@@ -203,7 +203,7 @@ class DenseBlock(tf.keras.Model):
   It consists of ConvBlocks where each block's output is concatenated
   with its input.
 
-  Arguments:
+  Args:
     num_layers: Number of layers in each block.
     growth_rate: number of filters to add per conv block.
     data_format: "channels_first" or "channels_last"
@@ -237,7 +237,7 @@ class DenseBlock(tf.keras.Model):
 class DenseNet(tf.keras.Model):
   """Creating the Densenet Architecture.
 
-  Arguments:
+  Args:
     mode: mode could be:
         - from_depth: num_layers_in_each_block will be calculated from the depth
                       and number of blocks.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420