### PR TITLE
Keep screen on and fix memory leak in Android Posenet demo

### DIFF
--- a/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/CameraActivity.kt
+++ b/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/CameraActivity.kt
@@ -17,6 +17,7 @@
 package org.tensorflow.lite.examples.posenet
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 
 class CameraActivity : AppCompatActivity() {
@@ -24,6 +25,7 @@ class CameraActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.tfe_pn_activity_camera)
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     savedInstanceState ?: supportFragmentManager.beginTransaction()
       .replace(R.id.container, PosenetActivity())
       .commit()

--- a/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/PosenetActivity.kt
+++ b/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/PosenetActivity.kt
@@ -549,17 +549,6 @@ class PosenetActivity :
       paint
     )
 
-//    val rt = Runtime.getRuntime()
-//    canvas.drawText(
-//      "Native/JVM: %.2f/%.2f GB".format(
-//        Debug.getNativeHeapSize() / (1024 * 1024 * 1024.0),
-//        (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024 * 1024.0)
-//      ),
-//      (15.0f * widthRatio),
-//      (90.0f * heightRatio + bottom),
-//      paint
-//    )
-
     // Draw!
     surfaceHolder!!.unlockCanvasAndPost(canvas)
   }

--- a/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/PosenetActivity.kt
+++ b/lite/examples/posenet/android/app/src/main/java/org/tensorflow/lite/examples/posenet/PosenetActivity.kt
@@ -35,8 +35,6 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CaptureRequest
-import android.hardware.camera2.CaptureResult
-import android.hardware.camera2.TotalCaptureResult
 import android.media.Image
 import android.media.ImageReader
 import android.media.ImageReader.OnImageAvailableListener
@@ -175,25 +173,6 @@ class PosenetActivity :
     override fun onError(cameraDevice: CameraDevice, error: Int) {
       onDisconnected(cameraDevice)
       this@PosenetActivity.activity?.finish()
-    }
-  }
-
-  /**
-   * A [CameraCaptureSession.CaptureCallback] that handles events related to JPEG capture.
-   */
-  private val captureCallback = object : CameraCaptureSession.CaptureCallback() {
-    override fun onCaptureProgressed(
-      session: CameraCaptureSession,
-      request: CaptureRequest,
-      partialResult: CaptureResult
-    ) {
-    }
-
-    override fun onCaptureCompleted(
-      session: CameraCaptureSession,
-      request: CaptureRequest,
-      result: TotalCaptureResult
-    ) {
     }
   }
 
@@ -570,6 +549,17 @@ class PosenetActivity :
       paint
     )
 
+//    val rt = Runtime.getRuntime()
+//    canvas.drawText(
+//      "Native/JVM: %.2f/%.2f GB".format(
+//        Debug.getNativeHeapSize() / (1024 * 1024 * 1024.0),
+//        (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024 * 1024.0)
+//      ),
+//      (15.0f * widthRatio),
+//      (90.0f * heightRatio + bottom),
+//      paint
+//    )
+
     // Draw!
     surfaceHolder!!.unlockCanvasAndPost(canvas)
   }
@@ -631,7 +621,7 @@ class PosenetActivity :
               previewRequest = previewRequestBuilder!!.build()
               captureSession!!.setRepeatingRequest(
                 previewRequest!!,
-                captureCallback, backgroundHandler
+                null, null
               )
             } catch (e: CameraAccessException) {
               Log.e(TAG, e.toString())


### PR DESCRIPTION
The backgroundHandler was holding a reference that was preventing native memory from getting cleaned up. The captureCallback implementation was not doing anything so there is no noticeable gain in having a backgroundHandler for captureSession!!.setRepeatingRequest().

It was leaking about 0.3 GB per minute. It is more noticeable when the screen is set to stay on because when the screen goes to sleep the backgroundHanler is released and the memory is cleaned up.  

Setting the setRepeatingRequest callback and handler to null seems to stop the leak.

It is hard to use the profiler because it slows everything down. I left in some commented code I used to monitor the memory while testing.