### PR TITLE
Fix condition in posenet example

### DIFF
--- a/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
@@ -30,7 +30,7 @@ extension CVPixelBuffer {
   ///   - to: Size to scale the image to(i.e. image size used while training the model).
   /// - Returns: The cropped and resized image of itself.
   func resize(from source: CGRect, to size: CGSize) -> CVPixelBuffer? {
-    let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: self.size)
+    let rect = CGRect(origin: .zero, size: self.size)
     guard rect.contains(source) else {
       os_log("Resizing Error: source area is out of index", type: .error)
       return nil

--- a/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
+++ b/lite/examples/posenet/ios/PoseNet/Extensions/CVPixelBufferExtension.swift
@@ -35,7 +35,7 @@ extension CVPixelBuffer {
       os_log("Resizing Error: source area is out of index", type: .error)
       return nil
     }
-    guard abs(rect.size.width / rect.size.height - source.size.width / source.size.height) < 1e-5
+    guard abs(size.width / size.height - source.size.width / source.size.height) < 1e-5
     else {
       os_log(
         "Resizing Error: source image ratio and destination image ratio is different",


### PR DESCRIPTION
Condition `abs(rect.size.width / rect.size.height - source.size.width / source.size.height)` checks wrong sizes. It should check size of source against size of destination. But it checks size of self against size of destination which is wrong.

There's confusing shadowing here: `size` as parameter and `size` property of self. It's better to give parameter different name e.g. `destSize`.