### PR TITLE
SoundClassification: Simplifies the existing code

### DIFF
--- a/lite/examples/sound_classification/android/app/build.gradle
+++ b/lite/examples/sound_classification/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 30
     defaultConfig {
         applicationId "org.tensorflow.lite.examples.soundclassifier"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
+++ b/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
@@ -27,8 +27,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import org.tensorflow.lite.Interpreter
-import org.tensorflow.lite.support.common.FileUtil
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -36,6 +34,8 @@ import java.nio.FloatBuffer
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.sin
+import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.support.common.FileUtil
 
 /**
  * Performs classification on sound.
@@ -143,7 +143,6 @@ class SoundClassifier(context: Context, private val options: Options = Options()
 
   /** Buffer that holds audio PCM sample that are fed to the TFLite model for inference.  */
   private lateinit var inputBuffer: FloatBuffer
-
 
   init {
     loadLabels(context)
@@ -278,7 +277,6 @@ class SoundClassifier(context: Context, private val options: Options = Options()
     recognitionThread = RecognitionThread().apply {
       start()
     }
-
   }
 
   private fun setupAudioRecord() {
@@ -320,8 +318,10 @@ class SoundClassifier(context: Context, private val options: Options = Options()
   }
 
   private fun loadAudio(audioBuffer: ShortArray): Int {
-    when (val loadedSamples =
-      audioRecord.read(audioBuffer, 0, audioBuffer.size, AudioRecord.READ_NON_BLOCKING)) {
+    when (
+      val loadedSamples =
+        audioRecord.read(audioBuffer, 0, audioBuffer.size, AudioRecord.READ_NON_BLOCKING)
+    ) {
       AudioRecord.ERROR_INVALID_OPERATION -> {
         Log.w(TAG, "AudioRecord.ERROR_INVALID_OPERATION")
       }
@@ -351,10 +351,10 @@ class SoundClassifier(context: Context, private val options: Options = Options()
       val outputBuffer = FloatBuffer.allocate(modelNumClasses)
       val recordingBuffer = ShortArray(modelInputLength)
       val circularBuffer = ShortArray(modelInputLength)
-      var j = 0  // Indices for the circular buffer next write
+
+      var j = 0 // Indices for the circular buffer next write
 
       while (!isInterrupted) {
-
         // Wait for the next invocation
         try {
           TimeUnit.MILLISECONDS.sleep(recognitionPeriod)
@@ -374,12 +374,13 @@ class SoundClassifier(context: Context, private val options: Options = Options()
           j = (j + 1) % circularBuffer.size
         }
 
-
         // Feed data to the input buffer.
         var samplesAreAllZero = true
         for (i in 0 until modelInputLength) {
           val s = if (i > options.pointsInAverage) {
-            ((i - options.pointsInAverage + 1)..i).map { circularBuffer[(j + it) % modelInputLength] }
+            ((i - options.pointsInAverage + 1)..i).map {
+              circularBuffer[(j + it) % modelInputLength]
+            }
               .average()
           } else {
             circularBuffer[(i + j) % modelInputLength]
@@ -425,4 +426,3 @@ private fun String.toTitleCase() =
     .map { it.capitalize(Locale.ROOT) }
     .joinToString(" ")
     .trim()
-

--- a/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
+++ b/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
@@ -33,7 +33,7 @@ import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
 import java.nio.FloatBuffer
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.sin
 
@@ -425,3 +425,4 @@ private fun String.toTitleCase() =
     .map { it.capitalize(Locale.ROOT) }
     .joinToString(" ")
     .trim()
+

--- a/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
+++ b/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/SoundClassifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ * Copyright 2021 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,18 +27,15 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.support.common.FileUtil
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
 import java.nio.FloatBuffer
-import java.util.Locale
+import java.util.*
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
-import kotlin.math.ceil
 import kotlin.math.sin
-import org.tensorflow.lite.Interpreter
-import org.tensorflow.lite.support.common.FileUtil
 
 /**
  * Performs classification on sound.
@@ -68,15 +65,13 @@ class SoundClassifier(context: Context, private val options: Options = Options()
     var probabilityThreshold: Float = 0.3f,
   )
 
-  val isRecording: Boolean
-    get() = recordingThread?.isAlive == true
+  var isRecording: Boolean = false
+    private set
 
   /** As the result of sound classification, this value emits map of probabilities */
   val probabilities: LiveData<Map<String, Float>>
     get() = _probabilities
   private val _probabilities = MutableLiveData<Map<String, Float>>()
-
-  private val recordingBufferLock: ReentrantLock = ReentrantLock()
 
   var isClosed: Boolean = true
     private set
@@ -141,14 +136,14 @@ class SoundClassifier(context: Context, private val options: Options = Options()
   /** Latest prediction latency in milliseconds.  */
   private var latestPredictionLatencyMs = 0f
 
-  private var recordingThread: Thread? = null
   private var recognitionThread: Thread? = null
 
-  private var recordingOffset = 0
-  private lateinit var recordingBuffer: ShortArray
+  /** Used to record audio samples. */
+  private lateinit var audioRecord: AudioRecord
 
   /** Buffer that holds audio PCM sample that are fed to the TFLite model for inference.  */
   private lateinit var inputBuffer: FloatBuffer
+
 
   init {
     loadLabels(context)
@@ -172,12 +167,13 @@ class SoundClassifier(context: Context, private val options: Options = Options()
 
   /**
    * Stops sound classification, which triggers interruption of
-   * `recordingThread` and `recognitionThread`.
+   * `recognitionThread`.
    */
   fun stop() {
     if (isClosed || !isRecording) return
-    recordingThread?.interrupt()
     recognitionThread?.interrupt()
+    audioRecord.stop()
+    isRecording = false
 
     _probabilities.postValue(labelList.associateWith { 0f })
   }
@@ -267,100 +263,83 @@ class SoundClassifier(context: Context, private val options: Options = Options()
     }
   }
 
-  /** Start a thread to pull audio samples in continuously.  */
+  /** Start recording and triggers recognition.  */
   @Synchronized
   private fun startAudioRecord() {
     if (isRecording) return
-    recordingThread = AudioRecordingThread().apply {
-      start()
-    }
+    setupAudioRecord()
     isClosed = false
+    isRecording = true
   }
 
   /** Start a thread that runs model inference (i.e., recognition) at a regular interval.  */
   private fun startRecognition() {
+    Log.i(TAG, "Starting Recognition")
     recognitionThread = RecognitionThread().apply {
       start()
     }
+
   }
 
-  /** Runnable class to run a thread for audio recording */
-  private inner class AudioRecordingThread : Thread() {
-    override fun run() {
-      var bufferSize = AudioRecord.getMinBufferSize(
-        options.sampleRate,
-        AudioFormat.CHANNEL_IN_MONO,
-        AudioFormat.ENCODING_PCM_16BIT
-      )
-      if (bufferSize == AudioRecord.ERROR || bufferSize == AudioRecord.ERROR_BAD_VALUE) {
-        bufferSize = options.sampleRate * 2
-        Log.w(TAG, "bufferSize has error or bad value")
-      }
-      Log.i(TAG, "bufferSize = $bufferSize")
-      val record = AudioRecord(
-        // including MIC, UNPROCESSED, and CAMCORDER.
-        MediaRecorder.AudioSource.VOICE_RECOGNITION,
-        options.sampleRate,
-        AudioFormat.CHANNEL_IN_MONO,
-        AudioFormat.ENCODING_PCM_16BIT,
-        bufferSize
-      )
-      if (record.state != AudioRecord.STATE_INITIALIZED) {
-        Log.e(TAG, "AudioRecord failed to initialize")
-        return
-      }
-      Log.i(TAG, "Successfully initialized AudioRecord")
-      val bufferSamples = bufferSize / 2
-      val audioBuffer = ShortArray(bufferSamples)
-      val recordingBufferSamples =
-        ceil(modelInputLength.toFloat() / bufferSamples.toDouble())
-          .toInt() * bufferSamples
-      Log.i(TAG, "recordingBufferSamples = $recordingBufferSamples")
-      recordingOffset = 0
-      recordingBuffer = ShortArray(recordingBufferSamples)
-      record.startRecording()
-      Log.i(TAG, "Successfully started AudioRecord recording")
+  private fun setupAudioRecord() {
+    var bufferSize = AudioRecord.getMinBufferSize(
+      options.sampleRate,
+      AudioFormat.CHANNEL_IN_MONO,
+      AudioFormat.ENCODING_PCM_16BIT
+    )
+    Log.i(TAG, "min buffer size = $bufferSize")
+    if (bufferSize == AudioRecord.ERROR || bufferSize == AudioRecord.ERROR_BAD_VALUE) {
+      bufferSize = options.sampleRate * 2
+      Log.w(TAG, "bufferSize has error or bad value")
+    }
+    // The buffer of AudioRecord should be larger than what model requires.
+    val modelRequiredBufferSize = 2 * modelInputLength * Short.SIZE_BYTES
+    if (bufferSize < modelRequiredBufferSize) {
+      bufferSize = modelRequiredBufferSize
+    }
+    Log.i(TAG, "bufferSize = $bufferSize")
+    audioRecord = AudioRecord(
+      // including MIC, UNPROCESSED, and CAMCORDER.
+      MediaRecorder.AudioSource.VOICE_RECOGNITION,
+      options.sampleRate,
+      AudioFormat.CHANNEL_IN_MONO,
+      AudioFormat.ENCODING_PCM_16BIT,
+      bufferSize
+    )
+    if (audioRecord.state != AudioRecord.STATE_INITIALIZED) {
+      Log.e(TAG, "AudioRecord failed to initialize")
+      return
+    }
+    Log.i(TAG, "Successfully initialized AudioRecord")
 
-      // Start recognition (model inference) thread.
-      startRecognition()
+    audioRecord.startRecording()
+    Log.i(TAG, "Successfully started AudioRecord recording")
 
-      while (!isInterrupted) {
-        try {
-          TimeUnit.MILLISECONDS.sleep(options.audioPullPeriod)
-        } catch (e: InterruptedException) {
-          Log.w(TAG, "Sleep interrupted in audio recording thread.")
-          break
-        }
-        when (record.read(audioBuffer, 0, audioBuffer.size)) {
-          AudioRecord.ERROR_INVALID_OPERATION -> {
-            Log.w(TAG, "AudioRecord.ERROR_INVALID_OPERATION")
-          }
-          AudioRecord.ERROR_BAD_VALUE -> {
-            Log.w(TAG, "AudioRecord.ERROR_BAD_VALUE")
-          }
-          AudioRecord.ERROR_DEAD_OBJECT -> {
-            Log.w(TAG, "AudioRecord.ERROR_DEAD_OBJECT")
-          }
-          AudioRecord.ERROR -> {
-            Log.w(TAG, "AudioRecord.ERROR")
-          }
-          bufferSamples -> {
-            // We apply locks here to avoid two separate threads (the recording and
-            // recognition threads) reading and writing from the recordingBuffer at the same
-            // time, which can cause the recognition thread to read garbled audio snippets.
-            recordingBufferLock.withLock {
-              audioBuffer.copyInto(
-                recordingBuffer,
-                recordingOffset,
-                0,
-                bufferSamples
-              )
-              recordingOffset = (recordingOffset + bufferSamples) % recordingBufferSamples
-            }
-          }
-        }
+    // Start recognition (model inference) thread.
+    startRecognition()
+  }
+
+  private fun loadAudio(audioBuffer: ShortArray): Int {
+    when (val loadedSamples =
+      audioRecord.read(audioBuffer, 0, audioBuffer.size, AudioRecord.READ_NON_BLOCKING)) {
+      AudioRecord.ERROR_INVALID_OPERATION -> {
+        Log.w(TAG, "AudioRecord.ERROR_INVALID_OPERATION")
+      }
+      AudioRecord.ERROR_BAD_VALUE -> {
+        Log.w(TAG, "AudioRecord.ERROR_BAD_VALUE")
+      }
+      AudioRecord.ERROR_DEAD_OBJECT -> {
+        Log.w(TAG, "AudioRecord.ERROR_DEAD_OBJECT")
+      }
+      AudioRecord.ERROR -> {
+        Log.w(TAG, "AudioRecord.ERROR")
+      }
+      else -> {
+        return loadedSamples
       }
     }
+    // No new sample was loaded.
+    return 0
   }
 
   private inner class RecognitionThread : Thread() {
@@ -370,36 +349,47 @@ class SoundClassifier(context: Context, private val options: Options = Options()
         return
       }
       val outputBuffer = FloatBuffer.allocate(modelNumClasses)
+      val recordingBuffer = ShortArray(modelInputLength)
+      val circularBuffer = ShortArray(modelInputLength)
+      var j = 0  // Indices for the circular buffer next write
+
       while (!isInterrupted) {
+
+        // Wait for the next invocation
         try {
           TimeUnit.MILLISECONDS.sleep(recognitionPeriod)
         } catch (e: InterruptedException) {
           Log.w(TAG, "Sleep interrupted in recognition thread.")
-          break
         }
+
+        // Load new audio samples
+        val sampleCounts = loadAudio(recordingBuffer)
+        if (sampleCounts == 0) {
+          continue
+        }
+
+        // Copy new data into the circular buffer
+        for (i in 0 until sampleCounts) {
+          circularBuffer[j] = recordingBuffer[i]
+          j = (j + 1) % circularBuffer.size
+        }
+
+
+        // Feed data to the input buffer.
         var samplesAreAllZero = true
-
-        recordingBufferLock.withLock {
-          var j = (recordingOffset - modelInputLength) % modelInputLength
-          if (j < 0) {
-            j += modelInputLength
+        for (i in 0 until modelInputLength) {
+          val s = if (i > options.pointsInAverage) {
+            ((i - options.pointsInAverage + 1)..i).map { circularBuffer[(j + it) % modelInputLength] }
+              .average()
+          } else {
+            circularBuffer[(i + j) % modelInputLength]
           }
-
-          for (i in 0 until modelInputLength) {
-            val s = if (i >= options.pointsInAverage && j >= options.pointsInAverage) {
-              ((j - options.pointsInAverage + 1)..j).map { recordingBuffer[it % modelInputLength] }
-                .average()
-            } else {
-              recordingBuffer[j % modelInputLength]
-            }
-            j += 1
-
-            if (samplesAreAllZero && s.toInt() != 0) {
-              samplesAreAllZero = false
-            }
-            inputBuffer.put(i, s.toFloat())
+          if (samplesAreAllZero && s.toInt() != 0) {
+            samplesAreAllZero = false
           }
+          inputBuffer.put(i, s.toFloat())
         }
+
         if (samplesAreAllZero) {
           Log.w(TAG, "No audio input: All audio samples are zero!")
           continue
@@ -414,6 +404,7 @@ class SoundClassifier(context: Context, private val options: Options = Options()
         val probList = predictionProbs.map {
           if (it > probabilityThreshold) it else 0f
         }
+        Log.i(TAG, "inference result: $probList")
         _probabilities.postValue(labelList.zip(probList).toMap())
 
         latestPredictionLatencyMs = ((SystemClock.elapsedRealtimeNanos() - t0) / 1e6).toFloat()


### PR DESCRIPTION
The existing code uses 2 threads, but actually only 1 of them is needed. This can be achieved by increasing the buffer size for AudioRecord.

Also bumps the min sdk as AudioRecord.READ_NON_BLOCKING requires SDK 23