### PR TITLE
Fixed Broken/Outdated link in   tensorflow/examples/CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Questions about TensorFlow usage are best addressed on
 mailing list.
 
 To contribute to the TensorFlow code repositories, see the
-[Contributing to TensorFlow](https://www.tensorflow.org/community/contributing) guide
+[Contributing to TensorFlow](https://www.tensorflow.org/community/contribute) guide
 and the
 [TensorFlow contribution guidelines](https://github.com/tensorflow/tensorflow/blob/master/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is the TensorFlow example repo.  It has several classes of material:
 * Publish supporting material for the [TensorFlow Blog](https://blog.tensorflow.org) and [TensorFlow YouTube Channel](https://youtube.com/tensorflow)
 
 We welcome community contributions, see [CONTRIBUTING.md](CONTRIBUTING.md) and, for style help,
-[Writing TensorFlow documentation](https://www.tensorflow.org/community/documentation)
+[Writing TensorFlow documentation](https://www.tensorflow.org/community/contribute/docs_style)
 guide.
 
 To file an issue, use the tracker in the


### PR DESCRIPTION
The https://www.tensorflow.org/community/contribute  in `tensorflow/examples/CONTRIBUTING.md`  was  mistyped as https://www.tensorflow.org/community/contributing, thus making it land on a 404 not find web page 
I fixed it