### PR TITLE
Changing the link for Community Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <h2>Most important links!</h2>
 
-* [Community examples](./community)
+* [Community examples](https://devlibrary.withgoogle.com/)
 * [Course materials](./courses/udacity_deep_learning) for the [Deep Learning](https://www.udacity.com/course/deep-learning--ud730) class on Udacity
 
 If you are looking to learn TensorFlow, don't miss the


### PR DESCRIPTION
With the removal of `examples/community` directory, the link for `Community examples` under Most Important Links in README.md resulted in a 404 landing page hence correcting it by adding this link https://devlibrary.withgoogle.com/

Instead, if this link needs to be removed too, will do that after the review by maintainers.