### PR TITLE
Add Open in Kaggle Badge

### DIFF
--- a/courses/udacity_deep_learning/1_notmnist.ipynb
+++ b/courses/udacity_deep_learning/1_notmnist.ipynb
@@ -8,8 +8,8 @@
       "source": [
         "Deep Learning\n",
         "=============\n",
-        "\n",
         "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/tensorflow/examples/blob/master/courses/udacity_deep_learning/1_notmnist.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
+        "<br></br>",
         "<br></br>",
         "Assignment 1\n",
         "------------\n",

--- a/courses/udacity_deep_learning/1_notmnist.ipynb
+++ b/courses/udacity_deep_learning/1_notmnist.ipynb
@@ -9,6 +9,8 @@
         "Deep Learning\n",
         "=============\n",
         "\n",
+        "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/tensorflow/examples/blob/master/courses/udacity_deep_learning/1_notmnist.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;",
+        "<br></br>",
         "Assignment 1\n",
         "------------\n",
         "\n",


### PR DESCRIPTION
Add Kaggle Badge that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480.

If this is something that makes sense for the repo I could expand in a further PR to the rest of the tutorial ipynbs with similar badges.

Alternatively is the style seen in the lite/examples repo e.g. https://github.com/tensorflow/examples/blob/master/lite/examples/digit_classifier/ml/mnist_tflite.ipynb