### PR TITLE
Fixed typos in ImageSegmentationModelExecutor.kt

### DIFF
--- a/lite/examples/image_segmentation/android/lib_task_api/src/main/java/org/tensorflow/lite/examples/imagesegmentation/tflite/ImageSegmentationModelExecutor.kt
+++ b/lite/examples/image_segmentation/android/lib_task_api/src/main/java/org/tensorflow/lite/examples/imagesegmentation/tflite/ImageSegmentationModelExecutor.kt
@@ -137,12 +137,12 @@ class ImageSegmentationModelExecutor(
     return Pair(Bitmap.createScaledBitmap(maskBitmap, inputWidth, inputHeight, true), itemsFound)
   }
 
-  private fun stackTwoBitmaps(foregrand: Bitmap, background: Bitmap): Bitmap {
+  private fun stackTwoBitmaps(foreground: Bitmap, background: Bitmap): Bitmap {
     val mergedBitmap =
-      Bitmap.createBitmap(foregrand.getWidth(), foregrand.getHeight(), foregrand.getConfig())
+      Bitmap.createBitmap(foreground.getWidth(), foreground.getHeight(), foreground.getConfig())
     val canvas = Canvas(mergedBitmap)
     canvas.drawBitmap(background, 0.0f, 0.0f, null)
-    canvas.drawBitmap(foregrand, 0.0f, 0.0f, null)
+    canvas.drawBitmap(foreground, 0.0f, 0.0f, null)
     return mergedBitmap
   }
 


### PR DESCRIPTION
Fixed a typo in 'foreground', parameter of stackTwoBitmaps() method