### PR TITLE
Initialize thread count from model instead of showing "1" by default.

### DIFF
--- a/lite/examples/image_classification/ios/ImageClassification/Storyboards/Base.lproj/Main.storyboard
+++ b/lite/examples/image_classification/ios/ImageClassification/Storyboards/Base.lproj/Main.storyboard
@@ -193,7 +193,7 @@
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sya-ll-mpl">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sya-ll-mpl">
                                         <rect key="frame" x="250.5" y="10" width="6.5" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/lite/examples/image_classification/ios/ImageClassification/ViewControllers/InferenceViewController.swift
+++ b/lite/examples/image_classification/ios/ImageClassification/ViewControllers/InferenceViewController.swift
@@ -76,6 +76,15 @@ class InferenceViewController: UIViewController {
   var resolution: CGSize = CGSize.zero
   var maxResults: Int = 0
   var threadCountLimit: Int = 0
+  var threadCount: Int {
+    get {
+      return currentThreadCount
+    }
+    set(value) {
+      currentThreadCount = value
+      threadStepper?.value = Double(value)
+    }
+  }
   private var currentThreadCount: Int = 0
   private var infoTextColor = UIColor.black
 
@@ -96,6 +105,7 @@ class InferenceViewController: UIViewController {
     threadStepper.maximumValue = Double(threadCountLimit)
     threadStepper.minimumValue = Double(minThreadCount)
     threadStepper.value = Double(currentThreadCount)
+    stepperValueLabel.text = "\(currentThreadCount)"
 
     // Set the info text color on iOS 11 and higher.
     if #available(iOS 11, *) {

--- a/lite/examples/image_classification/ios/ImageClassification/ViewControllers/ViewController.swift
+++ b/lite/examples/image_classification/ios/ImageClassification/ViewControllers/ViewController.swift
@@ -115,7 +115,7 @@ class ViewController: UIViewController {
       inferenceViewController?.maxResults = tempModelDataHandler.resultCount
       inferenceViewController?.threadCountLimit = tempModelDataHandler.threadCountLimit
       inferenceViewController?.delegate = self
-
+      inferenceViewController?.threadCount = tempModelDataHandler.threadCount
     }
   }
 


### PR DESCRIPTION
In the iOS image classification app, the UI currently always shows an initial thread count of 1, even if someone changes the initial thread count in the code.  (For example, by passing threadCount:2 into the ModelDataHandler init method.)  This change ensures the correct thread count is displayed.