### PR TITLE
handle bndbox dimensions stored as decimal

### DIFF
--- a/tensorflow_examples/lite/model_maker/third_party/efficientdet/dataset/create_pascal_tfrecord.py
+++ b/tensorflow_examples/lite/model_maker/third_party/efficientdet/dataset/create_pascal_tfrecord.py
@@ -176,10 +176,10 @@ def dict_to_tf_example(data,
       poses.append(obj['pose'].encode('utf8'))
 
       if ann_json_dict:
-        abs_xmin = int(obj['bndbox']['xmin'])
-        abs_ymin = int(obj['bndbox']['ymin'])
-        abs_xmax = int(obj['bndbox']['xmax'])
-        abs_ymax = int(obj['bndbox']['ymax'])
+        abs_xmin = int(float(obj['bndbox']['xmin']))
+        abs_ymin = int(float(obj['bndbox']['ymin']))
+        abs_xmax = int(float(obj['bndbox']['xmax']))
+        abs_ymax = int(float(obj['bndbox']['ymax']))
         abs_width = abs_xmax - abs_xmin
         abs_height = abs_ymax - abs_ymin
         ann = {


### PR DESCRIPTION
some tools will store the obj['bndbox']['xmin'] etc. as float which results in 'ValueError: invalid literal for int() with base 10'. This appears to have been missed from this section.