### PR TITLE
Resized the super resolution android screenshot

### DIFF
--- a/lite/examples/super_resolution/android/README.md
+++ b/lite/examples/super_resolution/android/README.md
@@ -12,7 +12,7 @@ Demo images are from [DIV2K dataset](https://data.vision.ee.ethz.ch/cvl/DIV2K/).
 This sample automatically downloads TFLite JAR files and uses TFLite C API
 through Android NDK.
 
-![SCREENSHOT](screenshot.jpg)
+<img src= https://raw.githubusercontent.com/tensorflow/examples/master/lite/examples/super_resolution/android/screenshot.jpg width="350" />
 
 ## Requirements
 


### PR DESCRIPTION
Resized the super-resolution Android screenshot to a smaller version
used <img/> tag, which is more flexible 