### PR TITLE
Updated pix2pix dataset download URL

### DIFF
--- a/tensorflow_examples/models/pix2pix/data_download.py
+++ b/tensorflow_examples/models/pix2pix/data_download.py
@@ -29,7 +29,7 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string('download_path', 'datasets', 'Download folder')
 
-_URL = 'https://people.eecs.berkeley.edu/~tinghuiz/projects/pix2pix/datasets/facades.tar.gz'
+_URL = 'http://efrosgans.eecs.berkeley.edu/pix2pix/datasets/facades.tar.gz'
 
 
 def _main(argv):


### PR DESCRIPTION
The current URL returns 404: the dataset has been moved to a different location.
HTTPS seems to not be correctly configured, so I chose HTTP instead.
Let me know if this is fine.
Thanks a lot.