### PR TITLE
changed readme title of text classification IOS sample

### DIFF
--- a/lite/examples/text_classification/ios/README.md
+++ b/lite/examples/text_classification/ios/README.md
@@ -1,4 +1,4 @@
-# Digit Classifier iOS sample
+# TensorFlow Lite text classification iOS sample
 
 <img src="screenshot.png" />
 


### PR DESCRIPTION
Rightnow we have readme title "Digit Classifier iOS sample" in the text classification IOS sample, I changed that to "TensorFlow Lite text classification iOS sample"