### PR TITLE
small-change

### DIFF
--- a/lite/examples/pose_estimation/raspberry_pi/utils.py
+++ b/lite/examples/pose_estimation/raspberry_pi/utils.py
@@ -63,7 +63,7 @@ def visualize(image: np.ndarray,
   """
   for person in list_persons:
     if person.score < instance_threshold:
-      continue
+      break
 
     keypoints = person.keypoints
     bounding_box = person.bounding_box


### PR DESCRIPTION
Hello. I changed the file 'https://github.com/tensorflow/examples/blob/master/lite/examples/pose_estimation/raspberry_pi/utils.py'  the 66 line. Since it only detects a single pose, there is no need to use 'continue' to continue the for loop. Also, if it uses 'continue', it will always execute the code below the 'continue'. As a consequence, even the input image of the model is totally black, it will show the box and some key-points.  
Therefore, break would be better than continue