### PR TITLE
Np average

### DIFF
--- a/lite/examples/pose_estimation/raspberry_pi/data.py
+++ b/lite/examples/pose_estimation/raspberry_pi/data.py
@@ -108,7 +108,7 @@ def person_from_keypoints_with_scores(
   # Calculate person score by averaging keypoint scores.
   scores_above_threshold = list(
       filter(lambda x: x > keypoint_score_threshold, scores))
-  person_score = np.average(scores_above_threshold) if scores_above_threshold else 0
+  person_score = np.average(scores_above_threshold) if scores_above_threshold != [] else 0
 
   return Person(keypoints, bounding_box, person_score)
 


### PR DESCRIPTION
In the file https://github.com/Charlie839242/examples/blob/master/lite/examples/pose_estimation/raspberry_pi/data.py, 111 line, it is possible that the score of 17 keypoints all don't reach the threshold. In this case, the np.average receives a empty list, which will cause some warnings like:
RuntimeWarning: Mean of empty slice.
RuntimeWarning: invalid value encountered in double_scalars

By adding 'scores_above_threshold = np.append(scores_above_threshold, 0)' can solve the problem.
