### PR TITLE
Update README.md

### DIFF
--- a/lite/examples/pose_estimation/raspberry_pi/README.md
+++ b/lite/examples/pose_estimation/raspberry_pi/README.md
@@ -49,8 +49,8 @@ python3 pose_estimation.py --model_name movenet_thunder
 
 ```
 python3 pose_estimation.py \
-    --classifier yoga_classifier
-    --label_file yoga_labels.txt
+    --classifier classifier
+    --label_file labels.txt
 ```
 
 ## Customization options


### PR DESCRIPTION
The yoga classifier model is downloaded as 'classifier.tflite', and the labels as 'labels.txt', without the yoga_ prefix.