### PR TITLE
Add option to load model weights from checkpoint before starting to t…

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -246,7 +246,8 @@ class EfficientDetModelSpec(object):
             validation_steps: int,
             epochs: Optional[int] = None,
             batch_size: Optional[int] = None,
-            val_json_file: Optional[str] = None) -> tf.keras.Model:
+            val_json_file: Optional[str] = None,
+            load_checkpoint_path: Optional[str] = None) -> tf.keras.Model:
     """Run EfficientDet training."""
     config = self.config
     if not epochs:
@@ -263,6 +264,10 @@ class EfficientDetModelSpec(object):
             batch_size=batch_size))
     train.setup_model(model, config)
     train.init_experimental(config)
+
+    if load_checkpoint_path is not None:
+      model.load_weights(load_checkpoint_path)
+
     model.fit(
         train_dataset,
         epochs=epochs,

--- a/tensorflow_examples/lite/model_maker/core/task/object_detector.py
+++ b/tensorflow_examples/lite/model_maker/core/task/object_detector.py
@@ -94,7 +94,8 @@ class ObjectDetector(custom_model.CustomModel):
             validation_data: Optional[
                 object_detector_dataloader.DataLoader] = None,
             epochs: Optional[int] = None,
-            batch_size: Optional[int] = None) -> tf.keras.Model:
+            batch_size: Optional[int] = None,
+            load_checkpoint_path: Optional[str] = None) -> tf.keras.Model:
     """Feeds the training data for training."""
     if not self.model_spec.config.drop_remainder:
       raise ValueError('Must set `drop_remainder=True` during training. '
@@ -122,7 +123,7 @@ class ObjectDetector(custom_model.CustomModel):
           validation_data, batch_size, is_training=False)
       return self.model_spec.train(self.model, train_ds, steps_per_epoch,
                                    validation_ds, validation_steps, epochs,
-                                   batch_size, val_json_file)
+                                   batch_size, val_json_file, load_checkpoint_path)
 
   def evaluate(self,
                data: object_detector_dataloader.DataLoader,
@@ -225,7 +226,8 @@ class ObjectDetector(custom_model.CustomModel):
              epochs: Optional[object_detector_dataloader.DataLoader] = None,
              batch_size: Optional[int] = None,
              train_whole_model: bool = False,
-             do_train: bool = True) -> T:
+             do_train: bool = True, 
+             load_checkpoint_path: Optional[str] = None) -> T:
     """Loads data and train the model for object detection.
 
     Args:
@@ -238,6 +240,8 @@ class ObjectDetector(custom_model.CustomModel):
         model. Otherwise, only train the layers that are not match
         `model_spec.config.var_freeze_expr`.
       do_train: Whether to run training.
+      load_checkpoint_path: Optional, Path to checkpoint to load model weights from, 
+        before training is started. 
 
     Returns:
       An instance based on ObjectDetector.
@@ -257,7 +261,7 @@ class ObjectDetector(custom_model.CustomModel):
 
     if do_train:
       tf.compat.v1.logging.info('Retraining the models...')
-      object_detector.train(train_data, validation_data, epochs, batch_size)
+      object_detector.train(train_data, validation_data, epochs, batch_size, load_checkpoint_path)
     else:
       object_detector.create_model()
 


### PR DESCRIPTION
Added an optional parameter that allows passing a path to a checkpoint file when calling objectdetector.create()
If a checkpoint path is passed, the underlying tf.keras.model will load the model weights from the checkpoint before training is started. 


