### PR TITLE
Upgrade 'com.android.tools.build:gradle' version to 4.2.0

### DIFF
--- a/lite/examples/bert_qa/android/build.gradle
+++ b/lite/examples/bert_qa/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/digit_classifier/android/build.gradle
+++ b/lite/examples/digit_classifier/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/lite/examples/gesture_classification/android/build.gradle
+++ b/lite/examples/gesture_classification/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/lite/examples/image_classification/android/build.gradle
+++ b/lite/examples/image_classification/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/image_segmentation/android/build.gradle
+++ b/lite/examples/image_segmentation/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
         // NOTE: Do not place your application dependencies here; they belong

--- a/lite/examples/object_detection/android/build.gradle
+++ b/lite/examples/object_detection/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/optical_character_recognition/android/build.gradle
+++ b/lite/examples/optical_character_recognition/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/lite/examples/pose_estimation/android/build.gradle
+++ b/lite/examples/pose_estimation/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:4.2.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/lite/examples/posenet/android/build.gradle
+++ b/lite/examples/posenet/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.0.0'
+    classpath 'com.android.tools.build:gradle:4.2.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/lite/examples/recommendation/android/build.gradle
+++ b/lite/examples/recommendation/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/reinforcement_learning/android/build.gradle
+++ b/lite/examples/reinforcement_learning/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/lite/examples/smart_reply/android/build.gradle
+++ b/lite/examples/smart_reply/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/sound_classification/android/build.gradle
+++ b/lite/examples/sound_classification/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2' // to download model
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/lite/examples/speech_commands/android/build.gradle
+++ b/lite/examples/speech_commands/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lite/examples/style_transfer/android/build.gradle
+++ b/lite/examples/style_transfer/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/lite/examples/super_resolution/android/build.gradle
+++ b/lite/examples/super_resolution/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.1.1'
     }
 }

--- a/lite/examples/text_classification/android/build.gradle
+++ b/lite/examples/text_classification/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath 'de.undercouch:gradle-download-task:4.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Recently I have faced with this issue https://youtrack.jetbrains.com/issue/KTIJ-19252

So this PR upgrade com.android.tools.build:gradle to 4.2.0 if it less

I think make sense to create some common config to keep all dependency versions in it