### PR TITLE
added bgr to rgb conversion

### DIFF
--- a/lite/examples/object_detection/raspberry_pi/detect.py
+++ b/lite/examples/object_detection/raspberry_pi/detect.py
@@ -72,7 +72,8 @@ def run(model: str, camera_id: int, width: int, height: int, num_threads: int,
     image = cv2.flip(image, 1)
 
     # Run object detection estimation using the model.
-    detections = detector.detect(image)
+    rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    detections = detector.detect(rgb_image)
 
     # Draw keypoints and edges on input image
     image = utils.visualize(image, detections)

--- a/lite/examples/object_detection/raspberry_pi/object_detector_test.py
+++ b/lite/examples/object_detection/raspberry_pi/object_detector_test.py
@@ -36,6 +36,7 @@ class ObjectDetectorTest(unittest.TestCase):
     super().setUp()
     self._load_ground_truth()
     self.image = cv2.imread(_IMAGE_FILE)
+    self.image = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB)
 
   def test_default_option(self):
     """Check if the default option works correctly."""


### PR DESCRIPTION
the efficientdet_lite0_edgetpu expects a RGB image but the images opened by open CV by default are in BRG fromat, 
fixed code so that images are converted to RGB before inference