### PR TITLE
 OCR Android example upgrade Opencv library version to 4.5.3.0

### DIFF
--- a/lite/examples/optical_character_recognition/android/README.md
+++ b/lite/examples/optical_character_recognition/android/README.md
@@ -7,7 +7,7 @@ pipeline to recognize texts.
 
 ## Requirements
 
-*   Android Studio 3.2 (installed on a Linux, Mac or Windows machine)
+*   Android Studio 4.2 (installed on a Linux, Mac or Windows machine)
 *   An Android device, or an Android Emulator
 
 ## Build and run

--- a/lite/examples/optical_character_recognition/android/app/build.gradle
+++ b/lite/examples/optical_character_recognition/android/app/build.gradle
@@ -84,5 +84,5 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:0.0.0-nightly-SNAPSHOT'
     implementation 'org.tensorflow:tensorflow-lite-support:0.0.0-nightly-SNAPSHOT'
 
-    implementation 'com.quickbirdstudios:opencv:4.3.0'
+    implementation 'com.quickbirdstudios:opencv:4.5.3.0'
 }


### PR DESCRIPTION
Because version quickbirdstudios:opencv:4.3.0 is currently unavailable.
https://github.com/quickbirdstudios/opencv-android
Upgrade the OpenCV library to lasted version (4.5.3.0).