### PR TITLE
Fixing sound classifier example app crash for the first time launch

### DIFF
--- a/lite/examples/sound_classification/android/README.md
+++ b/lite/examples/sound_classification/android/README.md
@@ -8,7 +8,7 @@ an audio event classification model.
 
 ## Requirements
 
-*   Android Studio 4.1 (installed on a Linux, Mac or Windows machine)
+*   Android Studio 4.2 (installed on a Linux, Mac or Windows machine)
 *   An Android device with Android 6.0+
 
 ## Build and run

--- a/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/MainActivity.kt
+++ b/lite/examples/sound_classification/android/app/src/main/java/org/tensorflow/lite/examples/soundclassifier/MainActivity.kt
@@ -145,7 +145,7 @@ class MainActivity : AppCompatActivity() {
 
   override fun onTopResumedActivityChanged(isTopResumedActivity: Boolean) {
     // Handles "top" resumed event on multi-window environment
-    if (isTopResumedActivity) {
+    if (isTopResumedActivity && isRecordAudioPermissionGranted()) {
       startAudioClassification()
     } else {
       stopAudioClassification()
@@ -169,15 +169,16 @@ class MainActivity : AppCompatActivity() {
 
   @RequiresApi(Build.VERSION_CODES.M)
   private fun requestMicrophonePermission() {
-    if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.RECORD_AUDIO
-            ) == PackageManager.PERMISSION_GRANTED
-    ) {
+    if (isRecordAudioPermissionGranted()) {
       startAudioClassification()
     } else {
       requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO)
     }
+  }
+
+  private fun isRecordAudioPermissionGranted(): Boolean {
+      return ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO
+      ) == PackageManager.PERMISSION_GRANTED
   }
 
   private fun keepScreenOn(enable: Boolean) =


### PR DESCRIPTION
The current implementation doesn't check if the app already has permission to record audio before starting the audio recorder. This PR fix this issue, preventing the app from crashing on first launch because it lacks the record audio permission.