### PR TITLE
Udacity TF Lite: Fix Cats vs Dogs dataset link in Transfer Learning with TensorFlow Hub for TFLite

### DIFF
--- a/courses/udacity_intro_to_tensorflow_lite/tflite_c02_transfer_learning.ipynb
+++ b/courses/udacity_intro_to_tensorflow_lite/tflite_c02_transfer_learning.ipynb
@@ -170,6 +170,8 @@
       },
       "outputs": [],
       "source": [
+        "setattr(tfds.image_classification.cats_vs_dogs, '_URL', \"https://download.microsoft.com/download/3/E/1/3E1C3F21-ECDB-4869-8368-6DEBA77B919F/kagglecatsanddogs_5340.zip\")\n",
+        "\n",
         "(train_examples, validation_examples, test_examples), info = tfds.load(\n",
         "    'cats_vs_dogs',\n",
         "    split=['train[80%:]', 'train[80%:90%]', 'train[90%:]'],\n",


### PR DESCRIPTION
- Loading the Cats vs Dogs dataset using TF Hub is not possible, as the host URL doesn't work (returns a 404 error).
- Related GitHub issue: https://github.com/tensorflow/datasets/issues/3918
- One potential solution is to use a `setattr` with a hardcoded URL that points to `kagglecatsanddogs_5340.zip`

