### PR TITLE
Incorrectly written parameter name in a docstring

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/task/custom_model.py
+++ b/tensorflow_examples/lite/model_maker/core/task/custom_model.py
@@ -118,7 +118,7 @@ class CustomModel(abc.ABC):
         {export_dir}/{tfjs_folder_name}.
       export_format: List of export format that could be saved_model, tflite,
         label, vocab.
-      **kwargs: Other parameters like `quantized_config` for TFLITE model.
+      **kwargs: Other parameters like `quantization_config` for TFLITE model.
     """
     export_format = self._get_export_format(export_format, **kwargs)
 


### PR DESCRIPTION
Correction of a parameter name  in a docstring of an export function. There is no parameter like "quantized_config". Name was corrected to "quantization_config".