### PR TITLE
Fix Pascal Conversion

### DIFF
--- a/tensorflow_examples/lite/model_maker/third_party/efficientdet/dataset/create_pascal_tfrecord.py
+++ b/tensorflow_examples/lite/model_maker/third_party/efficientdet/dataset/create_pascal_tfrecord.py
@@ -159,33 +159,39 @@ def dict_to_tf_example(data,
   difficult_obj = []
   if 'object' in data:
     for obj in data['object']:
-      if obj['difficult'] == 'Unspecified':
+      difficult_raw = obj.get('difficult')
+      if ((difficult_raw is None) or (difficult_raw == 'Unspecified')):
         difficult = False
       else:
-        difficult = bool(int(obj['difficult']))
+        difficult = bool(int(difficult_raw))
       if ignore_difficult_instances and difficult:
         continue
 
       difficult_obj.append(int(difficult))
 
-      xmin.append(float(obj['bndbox']['xmin']) / width)
-      ymin.append(float(obj['bndbox']['ymin']) / height)
-      xmax.append(float(obj['bndbox']['xmax']) / width)
-      ymax.append(float(obj['bndbox']['ymax']) / height)
+      xmin = float(obj['bndbox']['xmin'])
+      ymin = float(obj['bndbox']['ymin'])
+      xmax = float(obj['bndbox']['xmax'])
+      ymax = float(obj['bndbox']['ymax'])
+      xmin.append(xmin / width)
+      ymin.append(ymin / height)
+      xmax.append(xmax / width)
+      ymax.append(ymax / height)
       area.append((xmax[-1] - xmin[-1]) * (ymax[-1] - ymin[-1]))
       classes_text.append(obj['name'].encode('utf8'))
       classes.append(label_map_dict[obj['name']])
-      if obj['truncated'] == 'Unspecified':
+      truncated_raw = obj.get('truncated')
+      if ((truncated_raw is None) or (truncated_raw == 'Unspecified')):
         truncated.append(0)
       else:
-        truncated.append(int(obj['truncated']))
+        truncated.append(int(truncated_raw))
       poses.append(obj['pose'].encode('utf8'))
 
       if ann_json_dict:
-        abs_xmin = int(obj['bndbox']['xmin'])
-        abs_ymin = int(obj['bndbox']['ymin'])
-        abs_xmax = int(obj['bndbox']['xmax'])
-        abs_ymax = int(obj['bndbox']['ymax'])
+        abs_xmin = round(xmin)
+        abs_ymin = round(ymin)
+        abs_xmax = round(xmax)
+        abs_ymax = round(ymax)
         abs_width = abs_xmax - abs_xmin
         abs_height = abs_ymax - abs_ymin
         ann = {


### PR DESCRIPTION
Data exported from CVAT to the Pascal VOC format does not have the truncated or pose fields. It also specifies coordinates using float values instead of ints.

An earlier part of the code casts `obj['bndbox']['xmin']` to a float, so it seems valid to do this in the second place that accesses `obj['bndbox']['xmin']`, and just round this value. The behavior should be identical when values are ints. 

The behavior is identical when difficult and truncated fields are specified. However, this change also makes this code work correctly for files that do not contain these fields.