### PR TITLE
Added missing gradle-wrapper file

### DIFF
--- a/lite/examples/video_classification/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lite/examples/video_classification/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip


### PR DESCRIPTION
After cloning the repo, I couldn't build the app and got an Gradle error like I reported here: 
https://github.com/tensorflow/tensorflow/issues/57479

I solved this issue by adding the missing gradle-wrapper.properties file