### PR TITLE
Fix the syntax error in download gradle file of android style transfer project.

### DIFF
--- a/lite/examples/style_transfer/android/app/download_model.gradle
+++ b/lite/examples/style_transfer/android/app/download_model.gradle
@@ -48,6 +48,5 @@ task copyTestModel0(type: Copy, dependsOn: downloadModelFile) {
     into project.ext.TEST_ASSETS_DIR
 }
 
-preBuild.dependsOn
-        downloadModelFile, downloadModelFile0, downloadModelFile1,
+preBuild.dependsOn downloadModelFile, downloadModelFile0, downloadModelFile1,
         downloadModelFile2, copyTestModel, copyTestModel0


### PR DESCRIPTION
Fixed the syntax error in the download model gradle file of the android style transfer project. Because there is a syntax error here, users can't sync the project.