### PR TITLE
Removed dead links from examples/speech commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <h2>Most important links!</h2>
 
-* [Community examples](./community)
 * [Course materials](./courses/udacity_deep_learning) for the [Deep Learning](https://www.udacity.com/course/deep-learning--ud730) class on Udacity
 
 If you are looking to learn TensorFlow, don't miss the

--- a/lite/README.md
+++ b/lite/README.md
@@ -48,7 +48,7 @@ is highlighted.
 
 ### Samples
 
-[Android speech commands](examples/speech_commands/android/README.md)
+
 
 [iOS speech commands](examples/speech_commands/ios/README.md)
 

--- a/lite/examples/speech_commands/README.md
+++ b/lite/examples/speech_commands/README.md
@@ -9,8 +9,6 @@ samples with latest technologies.
 This directory contains end-to-end samples that performs recognition of speech
 commands on mobile, highlighting the spoken word.
 
-* An [Android app](android/) that uses the TensorFlow Lite model to recognize
-speech commands.
 * An [iOS app](ios/) that uses the TensorFlow Lite model to recognize
 speech commands.
 * A [guide](ml/) to generate speech commands TFLite model.


### PR DESCRIPTION
Removed dead links from examples/speech commands on android as Speech command does not have any android instruction.