### PR TITLE
summary method patch

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/task/custom_model.py
+++ b/tensorflow_examples/lite/model_maker/core/task/custom_model.py
@@ -63,7 +63,12 @@ class CustomModel(abc.ABC):
     return
 
   def summary(self):
-    self.model.summary()
+    # Cannot print summary if inherited class's create_model() is not called
+    try:
+      self.model.summary()
+    except:
+      print("The model has not been created")
+      
 
   @abc.abstractmethod
   def evaluate(self, data, **kwargs):


### PR DESCRIPTION
The child class (ObjectDetector) can call the summary method, but the model variable used within the method, self.model is only accessible after running the child method create_model