### PR TITLE
Fix to version numbering so that it is in accordance with PEP 404 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,10 @@ if '--nightly' in sys.argv:
   sys.argv.remove('--nightly')
 
 project_name = 'tensorflow-examples'
-# Get the current commit hash
-version = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8')
+# Get the current commit hash and timestamp
+commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+commit_timestamp = subprocess.check_output(['git', 'show', '-s', '--format=%ct', 'HEAD']).decode('utf-8').strip()
+version = f"0.{commit_timestamp}.{int(commit_hash, 16)}"
 
 if nightly:
   project_name = 'tensorflow-examples-nightly'

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,12 @@ if '--nightly' in sys.argv:
 
 project_name = 'tensorflow-examples'
 # Get the current commit hash and timestamp
-commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip()
+# The timestamp is used so that newer commits have a higher version number
+# The hash is used so that the specific commit can be identified
+# The hash integer can be converted back to the hash string with: '%032x' % commit_hash_int
+commit_hash_int = int(subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').strip(), 16)
 commit_timestamp = subprocess.check_output(['git', 'show', '-s', '--format=%ct', 'HEAD']).decode('utf-8').strip()
-version = f"0.{commit_timestamp}.{int(commit_hash, 16)}"
+version = f"0.{commit_timestamp}.{commit_hash_int}"
 
 if nightly:
   project_name = 'tensorflow-examples-nightly'


### PR DESCRIPTION
Recently I tried installing this repo through pip, and it failed with the following message:

```
raise InvalidVersion(f"Invalid version: '{version}'")
pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: 'b4eb09b4a3d167557d999723f7c2ed0d53a1bb7d-'
```

After some googling, I found that this is by design:

* https://github.com/pypa/setuptools/issues/2497
* https://github.com/pypa/setuptools/issues/3772

Apparently, `Setuptools` only supports version numbering in accordance with [PEP 404](https://peps.python.org/pep-0440/) from version 66 onwards. So I created a fork of this repo, changing the version numbering scheme so that it can be installed through pip.

The idea is essentially the same as it is currently, with only some minor modifications. Currently, the version number is simply the hash of the most recent commit, so there isn't any pattern or sequence to be worried about. PEP 404 required the version number to be in base 10, so I changed the base 16 representation of the commit hash to base 10. By keeping the commit hash, the commit can still be retrieved through the version number. I also prepended the commit's timestamp, so that the more recent commits have higher version numbering.