### PR TITLE
Fixed Broken/Outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <h2>Most important links!</h2>
 
-* [Community examples](./community)
+* [Community examples](https://devlibrary.withgoogle.com)
 * [Course materials](./courses/udacity_deep_learning) for the [Deep Learning](https://www.udacity.com/course/deep-learning--ud730) class on Udacity
 
 If you are looking to learn TensorFlow, don't miss the


### PR DESCRIPTION
In `tensorflow/examples/README.md`  the hyperlink to `Community examples` was referring to the community folder  which is no longer available thus leading it to land it on a 404 Page Not found web page. I fixed the link with the current updated link i.e `https://devlibrary.withgoogle.com`.