### PR TITLE
Alter the README.md in pose_estimation/raspberry_pi

### DIFF
--- a/lite/examples/pose_estimation/raspberry_pi/README.md
+++ b/lite/examples/pose_estimation/raspberry_pi/README.md
@@ -38,7 +38,7 @@ python3 pose_estimation.py
     *   The default value is `movenet_lightning`.
 
 ```
-python3 pose_estimation.py --model_name movenet_thunder
+python3 pose_estimation.py --model movenet_thunder
 ```
 
 ## Run the pose classification sample
@@ -49,7 +49,7 @@ python3 pose_estimation.py --model_name movenet_thunder
 
 ```
 python3 pose_estimation.py \
-    --classifier classifier
+    --classifier classifier.tflite
     --label_file labels.txt
 ```
 


### PR DESCRIPTION
I executed the TensorFlow pose_estimation.py on my raspberry pi 4 last weekend. However,  an error popped out when I added `--model_name movenet_multipose` behind pose_estimation.py. It said `--model model_name`. After reviewing the code in pose_estimation.py(line 161), I finally realized that the error is `--model_name`. Additionally, a similar problem occurred when I added `classifier classifier` behind the file. It is `classifier classifier.tflite` actually. Therefore, I want to replace `--model_name` with `--model` and `classifier classifier` with `classifier classifier.tflite` so that maybe it will be more user-friendly.