### PR TITLE
Update build.gradle

### DIFF
--- a/lite/examples/object_detection/android/build.gradle
+++ b/lite/examples/object_detection/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
         classpath 'de.undercouch:gradle-download-task:4.1.2'


### PR DESCRIPTION
Build fails using existing directions without upgrade to at least 7.3.0