### PR TITLE
Add updated environment setup instructions for Raspberry Pi OS Bookworm compatibility

### DIFF
--- a/lite/examples/audio_classification/raspberry_pi/README.md
+++ b/lite/examples/audio_classification/raspberry_pi/README.md
@@ -16,6 +16,69 @@ with Raspberry Pi OS (preferably updated to Buster).
 Raspberry Pi doesn't have a microphone integrated on its board, so you need to
 plug in a USB microphone to record audio.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the TensorFlow Lite runtime
 
 In this project, all you need from the TensorFlow Lite API is the `Interpreter`

--- a/lite/examples/audio_classification/raspberry_pi/README.md
+++ b/lite/examples/audio_classification/raspberry_pi/README.md
@@ -21,9 +21,9 @@ plug in a USB microphone to record audio.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -31,7 +31,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -41,19 +41,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -68,15 +72,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the TensorFlow Lite runtime

--- a/lite/examples/image_classification/raspberry_pi/README.md
+++ b/lite/examples/image_classification/raspberry_pi/README.md
@@ -24,6 +24,68 @@ to the Raspberry Pi. It's okay if you're using SSH to access the Pi shell
 attached to the Pi to see the camera stream.
 
 
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the TensorFlow Lite runtime
 
 In this project, all you need from the TensorFlow Lite API is the `Interpreter`

--- a/lite/examples/image_classification/raspberry_pi/README.md
+++ b/lite/examples/image_classification/raspberry_pi/README.md
@@ -28,9 +28,9 @@ attached to the Pi to see the camera stream.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -38,7 +38,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -48,19 +48,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -75,15 +79,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the TensorFlow Lite runtime

--- a/lite/examples/image_segmentation/raspberry_pi/README.md
+++ b/lite/examples/image_segmentation/raspberry_pi/README.md
@@ -23,6 +23,69 @@ Raspberry Pi. It's okay if you're using SSH to access the Pi shell (you don't
 need to use a keyboard connected to the Pi)—you only need a monitor attached to
 the Pi to see the camera stream.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the TensorFlow Lite runtime
 
 In this project, all you need from the TensorFlow Lite API is the `Interpreter`

--- a/lite/examples/image_segmentation/raspberry_pi/README.md
+++ b/lite/examples/image_segmentation/raspberry_pi/README.md
@@ -28,9 +28,9 @@ the Pi to see the camera stream.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -38,7 +38,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -48,19 +48,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -75,15 +79,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the TensorFlow Lite runtime

--- a/lite/examples/object_detection/raspberry_pi/README.md
+++ b/lite/examples/object_detection/raspberry_pi/README.md
@@ -24,6 +24,69 @@ Raspberry Pi. It's okay if you're using SSH to access the Pi shell (you don't
 need to use a keyboard connected to the Pi)—you only need a monitor attached to
 the Pi to see the camera stream.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Download the example files
 
 First, clone this Git repo onto your Raspberry Pi like this:

--- a/lite/examples/object_detection/raspberry_pi/README.md
+++ b/lite/examples/object_detection/raspberry_pi/README.md
@@ -29,9 +29,9 @@ the Pi to see the camera stream.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -39,7 +39,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -49,19 +49,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -76,15 +80,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Download the example files

--- a/lite/examples/pose_estimation/raspberry_pi/README.md
+++ b/lite/examples/pose_estimation/raspberry_pi/README.md
@@ -16,6 +16,69 @@ This sample can run on Raspberry Pi or any computer that has a camera. It uses
 OpenCV to capture images from the camera and TensorFlow Lite to run inference on
 the input image.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the dependencies
 
 *   Run this script to install the Python dependencies, and download the TFLite

--- a/lite/examples/pose_estimation/raspberry_pi/README.md
+++ b/lite/examples/pose_estimation/raspberry_pi/README.md
@@ -21,9 +21,9 @@ the input image.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -31,7 +31,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -41,19 +41,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -68,15 +72,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the dependencies

--- a/lite/examples/sound_classification/raspberry_pi/README.md
+++ b/lite/examples/sound_classification/raspberry_pi/README.md
@@ -16,6 +16,69 @@ with Raspberry Pi OS (preferably updated to Buster).
 Raspberry Pi doesn't have a microphone integrated on its board, so you need to
 plug in a USB microphone to record audio.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the TensorFlow Lite runtime
 
 In this project, all you need from the TensorFlow Lite API is the `Interpreter`

--- a/lite/examples/sound_classification/raspberry_pi/README.md
+++ b/lite/examples/sound_classification/raspberry_pi/README.md
@@ -21,9 +21,9 @@ plug in a USB microphone to record audio.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -31,7 +31,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -41,19 +41,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -68,15 +72,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the TensorFlow Lite runtime

--- a/lite/examples/video_classification/raspberry_pi/README.md
+++ b/lite/examples/video_classification/raspberry_pi/README.md
@@ -25,9 +25,9 @@ the Pi to see the camera stream.
 
 To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
 
-### Install Python 3.9
+### Install Python 3.9.0
 
-Follow these steps to install Python 3.9 from source:
+Follow these steps to install Python from source:
 
 1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
    ```bash
@@ -35,7 +35,7 @@ Follow these steps to install Python 3.9 from source:
    sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
    ```
 
-2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+2. **Compile and Install Python**: Download, extract, and install Python:
    ```bash
    wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
    tar xf Python-3.9.0.tar.xz
@@ -45,19 +45,23 @@ Follow these steps to install Python 3.9 from source:
    sudo make altinstall
    ```
 
-3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+3. **Verify Python Installation**: Ensure Python 3.9.0 is installed successfully:
    ```bash
    python3.9 --version
+   ```
+
+4. **Change Directory**: Move out of the Python source directory:
+   ```bash
+   cd ..
    ```
 
 ### Optional: Cleanup After Installation
 
 To optimize disk space after the Python installation:
 
-1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+1. **Remove Python Source Files**: Next, use `sudo` to  remove the downloaded archive and the extracted Python source directory:
    ```bash
-   cd ..
-   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   sudo rm -rf Python-3.9.0.tar.xz Python-3.9.0
    ```
 
 2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
@@ -72,15 +76,15 @@ Prepare and activate a virtual environment for the TensorFlow Lite examples:
 
 1. **Create the Environment**: 
    ```bash
-   python3.9 -m venv tflite
+   python3.9 -m venv /usr/local/venvs/tflite
    ```
 
 2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
    ```bash
-   source tflite/bin/activate
+   source /usr/local/venvs/tflite/bin/activate
    ```
 
-**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+**Note**: Remember to reactivate the `tflite` environment with `/usr/local/venvs/tflite/bin/activate` each time you work on the TensorFlow Lite examples.
 
 
 ## Install the TensorFlow Lite runtime

--- a/lite/examples/video_classification/raspberry_pi/README.md
+++ b/lite/examples/video_classification/raspberry_pi/README.md
@@ -20,6 +20,69 @@ Raspberry Pi. It's okay if you're using SSH to access the Pi shell (you don't
 need to use a keyboard connected to the Pi)—you only need a monitor attached to
 the Pi to see the camera stream.
 
+
+## Setup Environment
+
+To ensure the TensorFlow Lite examples run smoothly on Raspberry Pi OS based on Debian Bookworm (2024 release), setting up a Python virtual environment is crucial. This setup guarantees compatibility with Python 3.9 and effectively manages the dependencies for your examples.
+
+### Install Python 3.9
+
+Follow these steps to install Python 3.9 from source:
+
+1. **Install Build Dependencies**: Begin by updating your system and installing the required packages:
+   ```bash
+   sudo apt update
+   sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   ```
+
+2. **Compile and Install Python 3.9**: Download, extract, and install Python 3.9:
+   ```bash
+   wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+   tar xf Python-3.9.0.tar.xz
+   cd Python-3.9.0
+   ./configure --enable-optimizations --prefix=/usr
+   make -j $(nproc)
+   sudo make altinstall
+   ```
+
+3. **Verify Python Installation**: Ensure Python 3.9 is installed successfully:
+   ```bash
+   python3.9 --version
+   ```
+
+### Optional: Cleanup After Installation
+
+To optimize disk space after the Python installation:
+
+1. **Remove Python Source Files**: Eliminate the no-longer-needed source files:
+   ```bash
+   cd ..
+   rm -rf Python-3.9.0.tar.xz Python-3.9.0
+   ```
+
+2. **Remove Build Dependencies**: Optionally, uninstall the build dependencies if they are no longer necessary:
+   ```bash
+   sudo apt remove --purge -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget
+   sudo apt autoremove -y
+   ```
+
+### Virtual Environment Setup
+
+Prepare and activate a virtual environment for the TensorFlow Lite examples:
+
+1. **Create the Environment**: 
+   ```bash
+   python3.9 -m venv tflite
+   ```
+
+2. **Activate the Environment**: Always reactivate the virtual environment in new sessions:
+   ```bash
+   source tflite/bin/activate
+   ```
+
+**Note**: Remember to reactivate the `tflite` environment with `source tflite/bin/activate` each time you work on the TensorFlow Lite examples.
+
+
 ## Install the TensorFlow Lite runtime
 
 In this project, all you need from the TensorFlow Lite API is the `Interpreter`


### PR DESCRIPTION
 # Add updated environment setup instructions for Raspberry Pi OS Bookworm compatibility across 7 Raspberry Pi examples

This commit introduces a new 'Setup Environment' section in the README files of seven Raspberry Pi TensorFlow Lite examples to ensure compatibility with the Debian Bookworm (2024 release). These updates include detailed steps for installing Python 3.9, managing dependencies, and setting up a virtual environment, which are essential for addressing the specific needs of the latest Raspberry Pi OS version.

Additionally, the necessity of using a virtual environment is highlighted due to the error encountered when attempting to run `setup.sh` without it on this new OS version:

```
error: externally-managed-environment
```

This error emphasizes the importance of isolating Python environments to prevent conflicts with system-managed packages and maintain stability across different development scenarios.

Moreover, I encountered issues related to the specific Python version (3.11.2) used by the new OS, which necessitates this setup to ensure compatibility and address any potential `GLIBCXX` version errors when executing Python scripts:

```
ImportError: /lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.29' not found ...
```

By implementing these changes, I aim to provide a smooth setup experience for users working with Raspberry Pi TensorFlow Lite examples, ensuring that they can focus on development without being hindered by environmental issues.
