### PR TITLE
model_maker: Bump to Tensorflow 2.13

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/data_util/text_dataloader.py
+++ b/tensorflow_examples/lite/model_maker/core/data_util/text_dataloader.py
@@ -30,7 +30,7 @@ from tensorflow_examples.lite.model_maker.core.api import mm_export
 from tensorflow_examples.lite.model_maker.core.data_util import dataloader
 from tensorflow_examples.lite.model_maker.core.task import model_spec as ms
 
-from official.nlp.bert import input_pipeline
+from official.legacy.bert import input_pipeline
 from official.nlp.data import classifier_data_lib
 from official.nlp.data import squad_lib
 

--- a/tensorflow_examples/lite/model_maker/core/data_util/text_dataloader_test.py
+++ b/tensorflow_examples/lite/model_maker/core/data_util/text_dataloader_test.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v2 as tf
 
 from tensorflow_examples.lite.model_maker.core import test_util
 from tensorflow_examples.lite.model_maker.core.data_util import text_dataloader
-from official.nlp.bert import tokenization
+from official.nlp.tools import tokenization
 from official.nlp.data import squad_lib
 
 

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/text_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/text_spec.py
@@ -36,11 +36,11 @@ from tensorflow_examples.lite.model_maker.core.task.model_spec import util
 import tensorflow_hub as hub
 from tensorflow_hub import registry
 from official.nlp import optimization
-from official.nlp.bert import configs as bert_configs
-from official.nlp.bert import run_squad_helper
-from official.nlp.bert import squad_evaluate_v1_1
-from official.nlp.bert import squad_evaluate_v2_0
-from official.nlp.bert import tokenization
+from official.legacy.bert import configs as bert_configs
+from official.legacy.bert import run_squad_helper
+from official.nlp.tools import squad_evaluate_v1_1
+from official.nlp.tools import squad_evaluate_v2_0
+from official.nlp.tools import tokenization
 from official.nlp.data import classifier_data_lib
 from official.nlp.data import squad_lib
 from official.nlp.modeling import models

--- a/tensorflow_examples/lite/model_maker/requirements.txt
+++ b/tensorflow_examples/lite/model_maker/requirements.txt
@@ -1,8 +1,8 @@
 tf-models-official==2.3.0
 # tensorflow-hub is to load Hub model. Specific version is required by TFJS.
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"
-tensorflow-hub>=0.7.0,<0.13; python_version >= "3"
-numpy>=1.17.3,<1.23.4
+tensorflow-hub>=0.7.0; python_version >= "3"
+numpy>=1.17.3,<1.24.0
 pillow>=7.0.0
 sentencepiece>=0.1.91
 tensorflow-datasets>=2.1.0
@@ -26,4 +26,4 @@ tensorflow-addons>=0.11.2
 neural-structured-learning>=1.3.1
 tensorflow-model-optimization>=0.5
 Cython>=0.29.13
-scann==1.2.6
+scann>=1.2.6

--- a/tensorflow_examples/lite/model_maker/requirements.txt
+++ b/tensorflow_examples/lite/model_maker/requirements.txt
@@ -1,4 +1,4 @@
-tf-models-official==2.3.0
+tf-models-official>=2.13.0,<2.14.0
 # tensorflow-hub is to load Hub model. Specific version is required by TFJS.
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"
 tensorflow-hub>=0.7.0; python_version >= "3"
@@ -12,7 +12,7 @@ absl-py>=0.10.0
 urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
 tflite-support>=0.4.2
 tensorflowjs>=2.4.0,<3.19.0
-tensorflow>=2.6.0
+tensorflow>=2.13.0
 # b/196287362: This Numba + Librosa combination works for numpy 1.19, introduced
 # by TensorFlow 2.6.0.
 numba>=0.53


### PR DESCRIPTION
By relaxing constraints in requirements.txt and adapting the code to the refactoring of newer versions of `tf-models-official`.