### PR TITLE
problems in "densenet" and "nmt_with_attention"

### DIFF
--- a/tensorflow_examples/models/densenet/densenet.py
+++ b/tensorflow_examples/models/densenet/densenet.py
@@ -188,7 +188,7 @@ class TransitionBlock(tf.keras.Model):
                                        data_format=data_format,
                                        kernel_initializer="he_normal",
                                        kernel_regularizer=l2(weight_decay))
-    self.avg_pool = tf.keras.layers.AveragePooling2D(data_format=data_format)
+    self.avg_pool = tf.keras.layers.AveragePooling2D(pool_size(2,2),data_format=data_format)
 
   def call(self, x, training=True):
     output = self.batchnorm(x, training=training)

--- a/tensorflow_examples/models/nmt_with_attention/train.py
+++ b/tensorflow_examples/models/nmt_with_attention/train.py
@@ -154,8 +154,8 @@ class Train(object):
     template = 'Epoch: {}, Train Loss: {}, Test Loss: {}'
 
     for epoch in range(self.epochs):
-      self.train_loss_metric.reset_states()
-      self.test_loss_metric.reset_states()
+      self.train_loss_metric.reset_state()
+      self.test_loss_metric.reset_state()
 
       for inp, targ in train_ds:
         self.train_step((inp, targ))


### PR DESCRIPTION
tensorflow version:2.16.1
python version:3.11.4

**- densenet**

1. path:examples/tensorflow_examples/models/densenet
2. problem:TypeError: AveragePooling2D.__init__() missing 1 required positional argument: 'pool_size'
3. change:change the line "self. avg_pool = tf.keras.layers.AveragePooling2D(data_format=data_format)" in the file “densenet.py” to "self. avg_pool = tf.keras.layers.AveragePooling2D(pool_size(2,2),data_format=data_format)"

**- nmt_with_attention**

1. path:examples/tensorflow_examples/models/nmt_with_attention
2. problem:AttributeError: 'Mean' object has no attribute 'reset_states' 
3. change:change "reset_states()" in the file "train.py" to "reset_state()"