### PR TITLE
Samples: ObjectDetection - Upgrade Gradle to 8.5.0 and Kotlin 1.9.23

### DIFF
--- a/lite/examples/object_detection/android_play_services/app/build.gradle
+++ b/lite/examples/object_detection/android_play_services/app/build.gradle
@@ -21,12 +21,13 @@ apply plugin: "androidx.navigation.safeargs"
 apply plugin: 'de.undercouch.download'
 
 android {
-    compileSdkVersion 32
+    namespace 'org.tensorflow.lite.examples.objectdetection'
+    compileSdkVersion 34
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         applicationId "org.tensorflow.lite.examples.objectdetection"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0.0"
     }

--- a/lite/examples/object_detection/android_play_services/build.gradle
+++ b/lite/examples/object_detection/android_play_services/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.9.23'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -11,9 +11,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7'
         classpath 'de.undercouch:gradle-download-task:4.1.2'
 
 

--- a/lite/examples/object_detection/android_play_services/gradle/wrapper/gradle-wrapper.properties
+++ b/lite/examples/object_detection/android_play_services/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The example for object detection can now be build with the newest android studio