### PR TITLE
Removes tensorboard callback from being hardcoded

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/data_util/object_detector_dataloader_util.py
+++ b/tensorflow_examples/lite/model_maker/core/data_util/object_detector_dataloader_util.py
@@ -334,6 +334,8 @@ def _get_xml_dict_from_csv_lines(images_dir: str, image_filename: str,
 
   for line in lines:
     label = line[2].strip()
+    if label =='':
+      continue
     xmin, ymin = float(line[3]) * width, float(line[4]) * height
     xmax, ymax = float(line[7]) * width, float(line[8]) * height
     obj = {

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/__init__.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/__init__.py
@@ -108,6 +108,8 @@ def get(spec_or_str, *args, **kwargs):
 
   if inspect.isclass(model_spec) or inspect.isfunction(
       model_spec) or isinstance(model_spec, functools.partial):
+    print(args)
+    print(kwargs)
     return model_spec(*args, **kwargs)
   else:
     return model_spec

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -131,8 +131,7 @@ class EfficientDetModelSpec(object):
                profile: bool = False,
                debug: bool = False,
                tf_random_seed: int = 111111,
-               verbose: int = 0,
-               test: str = "") -> None:
+               verbose: int = 0 ) -> None:
 
     """Initialze an instance with model paramaters.
 

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -273,7 +273,7 @@ class EfficientDetModelSpec(object):
     callbacks = config_callbacks + callbacks
 
     tb_callback = tf.keras.callbacks.TensorBoard(
-        log_dir=self.config['model_dir'] or './',
+        log_dir=self.config['model_dir'] or '/tmp/tensorboard/',
         update_freq=self.config['steps_per_execution'] or '24',
         profile_batch=2 if self.config['profile'] else 0)
     

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -269,12 +269,6 @@ class EfficientDetModelSpec(object):
     config_callbacks = train_lib.get_callbacks(config.as_dict(), val_dataset)
     callbacks = config_callbacks + callbacks
 
-    tb_callback = tf.keras.callbacks.TensorBoard(
-        log_dir=self.config['model_dir'] or '/tmp/tensorboard/',
-        update_freq=self.config['steps_per_execution'] or '24',
-        profile_batch=2 if self.config['profile'] else 0)
-    
-    callbacks.append(tb_callback)
     print(f"Our callbacks are {callbacks}")
     
     model.fit(

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -172,7 +172,6 @@ class EfficientDetModelSpec(object):
         for debugging.
       verbose: verbosity mode for `tf.keras.callbacks.ModelCheckpoint`, 0 or 1.
     """
-    self.test_string = test
     self.model_name = model_name
     self.uri = uri
     self.batch_size = batch_size
@@ -267,7 +266,6 @@ class EfficientDetModelSpec(object):
             batch_size=batch_size))
     train.setup_model(model, config)
     train.init_experimental(config)
-    print(f"yep this is the one!! {self.test_string}")
 
     config_callbacks = train_lib.get_callbacks(config.as_dict(), val_dataset)
     callbacks = config_callbacks + callbacks

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -131,7 +131,9 @@ class EfficientDetModelSpec(object):
                profile: bool = False,
                debug: bool = False,
                tf_random_seed: int = 111111,
-               verbose: int = 0) -> None:
+               verbose: int = 0,
+               test: str = "") -> None:
+
     """Initialze an instance with model paramaters.
 
     Args:
@@ -170,6 +172,7 @@ class EfficientDetModelSpec(object):
         for debugging.
       verbose: verbosity mode for `tf.keras.callbacks.ModelCheckpoint`, 0 or 1.
     """
+    self.test_string = test
     self.model_name = model_name
     self.uri = uri
     self.batch_size = batch_size
@@ -262,7 +265,7 @@ class EfficientDetModelSpec(object):
             batch_size=batch_size))
     train.setup_model(model, config)
     train.init_experimental(config)
-    print("yep this is the one!!")
+    print(f"yep this is the one!! {self.test_string}")
     model.fit(
         train_dataset,
         epochs=epochs,

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -262,6 +262,7 @@ class EfficientDetModelSpec(object):
             batch_size=batch_size))
     train.setup_model(model, config)
     train.init_experimental(config)
+    print("yep this is the one!!")
     model.fit(
         train_dataset,
         epochs=epochs,

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -273,9 +273,9 @@ class EfficientDetModelSpec(object):
     callbacks = config_callbacks + callbacks
 
     tb_callback = tf.keras.callbacks.TensorBoard(
-        log_dir=self.params['model_dir'],
-        update_freq=self.params['steps_per_execution'],
-        profile_batch=2 if self.params['profile'] else 0)
+        log_dir=self.config['model_dir'] or './',
+        update_freq=self.config['steps_per_execution'] or '24',
+        profile_batch=2 if self.config['profile'] else 0)
     
     callbacks.append(tb_callback)
     print(f"Our callbacks are {callbacks}")

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec_test.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec_test.py
@@ -27,7 +27,7 @@ class EfficientDetModelSpecTest(tf.test.TestCase):
   @classmethod
   def setUpClass(cls):
     super(EfficientDetModelSpecTest, cls).setUpClass()
-    hub_path = test_util.get_test_data_path('fake_effdet_lite0_hub')
+    hub_path = test_util.get_test_data_path('./testdata/fake_effdet_lite0_hub')
     cls._spec = object_detector_spec.EfficientDetModelSpec(
         model_name='efficientdet-lite0', uri=hub_path, hparams=dict(map_freq=1))
     with cls._spec.ds_strategy.scope():

--- a/tensorflow_examples/lite/model_maker/core/task/object_detector.py
+++ b/tensorflow_examples/lite/model_maker/core/task/object_detector.py
@@ -15,7 +15,7 @@
 
 import os
 import tempfile
-from typing import Dict, Optional, Tuple, TypeVar
+from typing import Dict, List, Optional, Tuple, TypeVar
 
 import tensorflow as tf
 from tensorflow_examples.lite.model_maker.core import compat
@@ -94,7 +94,8 @@ class ObjectDetector(custom_model.CustomModel):
             validation_data: Optional[
                 object_detector_dataloader.DataLoader] = None,
             epochs: Optional[int] = None,
-            batch_size: Optional[int] = None) -> tf.keras.Model:
+            batch_size: Optional[int] = None,
+            callbacks: Optional[List[tf.keras.callbacks.Callback]] = []) -> tf.keras.Model:
     """Feeds the training data for training."""
     if not self.model_spec.config.drop_remainder:
       raise ValueError('Must set `drop_remainder=True` during training. '
@@ -122,7 +123,7 @@ class ObjectDetector(custom_model.CustomModel):
           validation_data, batch_size, is_training=False)
       return self.model_spec.train(self.model, train_ds, steps_per_epoch,
                                    validation_ds, validation_steps, epochs,
-                                   batch_size, val_json_file)
+                                   batch_size, val_json_file, callbacks)
 
   def evaluate(self,
                data: object_detector_dataloader.DataLoader,

--- a/tensorflow_examples/lite/model_maker/core/task/object_detector.py
+++ b/tensorflow_examples/lite/model_maker/core/task/object_detector.py
@@ -226,7 +226,9 @@ class ObjectDetector(custom_model.CustomModel):
              epochs: Optional[object_detector_dataloader.DataLoader] = None,
              batch_size: Optional[int] = None,
              train_whole_model: bool = False,
-             do_train: bool = True) -> T:
+             do_train: bool = True,
+             callbacks: Optional[List[tf.keras.callbacks.Callback]] = []
+             ) -> T:
     """Loads data and train the model for object detection.
 
     Args:
@@ -258,7 +260,7 @@ class ObjectDetector(custom_model.CustomModel):
 
     if do_train:
       tf.compat.v1.logging.info('Retraining the models...')
-      object_detector.train(train_data, validation_data, epochs, batch_size)
+      object_detector.train(train_data, validation_data, epochs, batch_size, callbacks)
     else:
       object_detector.create_model()
 

--- a/tensorflow_examples/lite/model_maker/requirements.txt
+++ b/tensorflow_examples/lite/model_maker/requirements.txt
@@ -1,3 +1,4 @@
+kaggle==1.6.14
 tf-models-official==2.3.0
 # tensorflow-hub is to load Hub model. Specific version is required by TFJS.
 tensorflow-hub>=0.7.0,<0.10; python_version < "3"


### PR DESCRIPTION
Attempting to fix  
```
File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/ops/summary_ops_v2.py", line 93, in __exit__
    _summary_state.writer.flush()
AttributeError: 'NoneType' object has no attribute 'flush'
```