### PR TITLE
passing np array to predict function

### DIFF
--- a/courses/udacity_intro_to_tensorflow_for_deep_learning/l02c01_celsius_to_fahrenheit.ipynb
+++ b/courses/udacity_intro_to_tensorflow_for_deep_learning/l02c01_celsius_to_fahrenheit.ipynb
@@ -356,7 +356,7 @@
       },
       "outputs": [],
       "source": [
-        "print(model.predict([100.0]))"
+        "print(model.predict(np.array([100.0])))"
       ]
     },
     {
@@ -432,7 +432,7 @@
         "model.compile(loss='mean_squared_error', optimizer=tf.keras.optimizers.Adam(0.1))\n",
         "model.fit(celsius_q, fahrenheit_a, epochs=500, verbose=False)\n",
         "print(\"Finished training the model\")\n",
-        "print(model.predict([100.0]))\n",
+        "print(model.predict(np.array([100.0])))\n",
         "print(\"Model predicts that 100 degrees Celsius is: {} degrees Fahrenheit\".format(model.predict([100.0])))\n",
         "print(\"These are the l0 variables: {}\".format(l0.get_weights()))\n",
         "print(\"These are the l1 variables: {}\".format(l1.get_weights()))\n",


### PR DESCRIPTION
In order to fix the following error : 

`Traceback (most recent call last):
  File "/dev/examples/courses/hands-on/l02c01_celsius_to_fahrenheit.py", line 31, in <module>
    print(model.predict([100.0]))
  File "/dev/examples/.venv/lib/python3.9/site-packages/keras/src/utils/traceback_utils.py", line 122, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/dev//examples/.venv/lib/python3.9/site-packages/keras/src/trainers/data_adapters/__init__.py", line 125, in get_data_adapter
    raise ValueError(f"Unrecognized data type: x={x} (of type {type(x)})")
ValueError: Unrecognized data type: x=[100.0] (of type <class 'list'>)`

model.predict() function in TensorFlow expects its input to be a NumPy array or a Tensor, not a Python list 